### PR TITLE
Basic muted channel support

### DIFF
--- a/lib/model/channel.js
+++ b/lib/model/channel.js
@@ -18,6 +18,7 @@ class Channel {
     this.isPrivate = false
     this.isDefault = false
     this.isMultiParty = false
+    this.isMuted = false
 
     // Whether all messages of channel have been read.
     this.isRead = true

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -9,13 +9,22 @@ const SlackUser = require('./slack-user')
 const imageStore = require('../../controller/image-store')
 
 function compareChannel(a, b) {
-  a = a.name.toUpperCase()
-  b = b.name.toUpperCase()
-  if (a < b)
-    return -1
-  if (a > b)
+  const nameA = a.name.toUpperCase()
+  const nameB = b.name.toUpperCase()
+
+  // Push muted channels to bottom of list.
+  if (a.is_muted === b.is_muted) {
+    if (nameA < nameB)
+      return -1
+    if (nameA > nameB)
+      return 1
+    return 0
+  }
+
+  if (a.is_muted)
     return 1
-  return 0
+
+  return -1
 }
 
 function filterChannel(c) {

--- a/lib/service/slack/slack-channel.js
+++ b/lib/service/slack/slack-channel.js
@@ -31,6 +31,8 @@ class SlackChannel extends Channel {
     if (channel.purpose)
       this.description = channel.purpose.value ? channel.purpose.value
                                                : '(No description)'
+    if (channel.is_muted)
+      this.isMuted = true
   }
 
   async readMessagesImpl() {

--- a/lib/view/channel-item.js
+++ b/lib/view/channel-item.js
@@ -82,6 +82,9 @@ class ChannelItem {
     }
     if (this.disabled) {
       attributes.color = DISABLED_COLOR
+    } else if (this.channel.isMuted) {
+      if (!this.isSelected)
+        attributes.color = DISABLED_COLOR
     } else if (!this.channel.isRead) {
       attributes.font = UNREAD_FONT
       attributes.color = SELECTED_COLOR


### PR DESCRIPTION
- Greys out muted channels
- Groups muted channels at the bottom of the channels list, preserving alpha sort

Example (channel names truncated):

![screenshot](https://i.imgur.com/bvpWBed.png)