### PR TITLE
slack-account: fix message changed timestamp

### DIFF
--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -192,8 +192,8 @@ class SlackAccount extends Account {
           channel.deleteMessage(event.deleted_ts, event.deleted_ts)
           break
         case 'message_changed':
-          channel.modifyMessage(event.previous_message.ts,
-                                event.previous_message.ts,
+          channel.modifyMessage(event.message.ts,
+                                event.message.ts,
                                 event.message.text)
           break
         default:


### PR DESCRIPTION
Per https://api.slack.com/events/message/message_changed, the property should be 'message' not 'previous_message'.