### PR TITLE
feat(channel): presence indicator for 1:1 DMs

### DIFF
--- a/lib/model/account.js
+++ b/lib/model/account.js
@@ -45,6 +45,11 @@ class Account {
     return channel
   }
 
+  // DMs treated as channels.
+  findChannelByUserId(id) {
+    return this.dms.find((c) => c.userId === id)
+  }
+
   computeReadState() {
     const compute = (r, c) => { return (c.isRead || c.isMuted) ? r : false }
     return this.channels.reduce(compute, this.dms.reduce(compute, true))

--- a/lib/model/channel.js
+++ b/lib/model/channel.js
@@ -12,6 +12,7 @@ class Channel {
     this.id = id
     this.name = name
 
+    this.userId = null
     this.description = '(No description)'
     this.messages = []
     this.isMember = false
@@ -19,6 +20,7 @@ class Channel {
     this.isDefault = false
     this.isMultiParty = false
     this.isMuted = false
+    this.isAway = false
 
     // Whether all messages of channel have been read.
     this.isRead = true
@@ -57,6 +59,7 @@ class Channel {
     this.onDeleteMessage = new Signal()
     this.onModifyMessage = new Signal()
     this.onUpdateReadState = new Signal()
+    this.onUpdateAwayState = new Signal()
   }
 
   markRead() {
@@ -269,6 +272,11 @@ class Channel {
 
   async notifyReadImpl() {
     throw new Error('Should be implemented by subclasses')
+  }
+
+  setAway(isAway) {
+    this.isAway = isAway
+    this.onUpdateAwayState.dispatch()
   }
 }
 

--- a/lib/service/slack/index.js
+++ b/lib/service/slack/index.js
@@ -41,7 +41,7 @@ class SlackService extends Service {
       this.loginWindow.close()
       new SlackAccount(this, data, rtm)
     })
-    rtm.start()
+    rtm.start({batch_presence_aware: true})
   }
 
   createLoginWindow() {

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -46,7 +46,7 @@ class SlackAccount extends Account {
       require('./private-apis').extend(this.rtm)
       this.rtm.once('unable_to_rtm_start', this.reportError.bind(this))
       this.rtm.once('authenticated', this.ready.bind(this))
-      this.rtm.start()
+      this.rtm.start({batch_presence_aware: true})
     } else {
       super(service, {id: data.team.id, name: data.team.name})
       this.rtm = rtm
@@ -84,6 +84,8 @@ class SlackAccount extends Account {
     this.rtm.on('group_archive', this.leaveChannel.bind(this))
     this.rtm.on('group_close', this.leaveChannel.bind(this))
     this.rtm.on('group_left', this.leaveChannel.bind(this))
+
+    this.rtm.on('presence_change', this.handlePresenceChange.bind(this))
   }
 
   serialize() {
@@ -100,7 +102,7 @@ class SlackAccount extends Account {
 
   async reload() {
     if (this.status === 'disconnected')
-      this.rtm.start()
+      this.rtm.start({batch_presence_aware: true})
     else if (this.status === 'connected')
       await this.updateChannels()
   }
@@ -131,6 +133,8 @@ class SlackAccount extends Account {
     const {members} = await this.rtm.webClient.users.list()
     for (const m of members)
       this.users[m.id] = new SlackUser(m)
+    // Online/away status.
+    this.rtm.subscribePresence(Object.keys(this.users))
     // Current user.
     this.currentUserId = data.self.id
     // Fetch channels.
@@ -150,8 +154,12 @@ class SlackAccount extends Account {
                             .sort(compareChannel)
                             .map((c) => new SlackChannel(this, 'channel', c))
     this.dms = ims.concat(mpims)
-                             .filter(filterChannel)
-                             .map((c) => new SlackChannel(this, 'dm', c))
+                  .filter(filterChannel)
+                  .map((c) => {
+                    if (c.is_im)
+                      c.is_away = this.findUserById(c.user_id).isAway
+                    return new SlackChannel(this, 'dm', c)
+                  })
     // Notify.
     this.setReadState(this.computeReadState())
     this.isChannelsReady = true
@@ -237,6 +245,16 @@ class SlackAccount extends Account {
       return
     this.onRemoveChannel.dispatch(index, this.channels[index])
     this.channels.splice(index, 1)
+  }
+
+  handlePresenceChange(event) {
+    const user = this.findUserById(event.user)
+    if (!user)
+      return
+    user.setAway(event.presence === 'away')
+    const userChannel = this.findChannelByUserId(user.id)
+    if (userChannel)
+      userChannel.setAway(event.presence === 'away')
   }
 
   async openDM(event) {

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -133,8 +133,6 @@ class SlackAccount extends Account {
     const {members} = await this.rtm.webClient.users.list()
     for (const m of members)
       this.users[m.id] = new SlackUser(m)
-    // Online/away status.
-    this.rtm.subscribePresence(Object.keys(this.users))
     // Current user.
     this.currentUserId = data.self.id
     // Fetch channels.
@@ -160,6 +158,9 @@ class SlackAccount extends Account {
                       c.is_away = this.findUserById(c.user_id).isAway
                     return new SlackChannel(this, 'dm', c)
                   })
+
+    // Online/away status.
+    this.rtm.subscribePresence(ims.map(im => im.user_id))
     // Notify.
     this.setReadState(this.computeReadState())
     this.isChannelsReady = true

--- a/lib/service/slack/slack-channel.js
+++ b/lib/service/slack/slack-channel.js
@@ -21,6 +21,9 @@ class SlackChannel extends Channel {
         if (channel.is_mpim) {
           this.isMultiParty = true
           this.name = this.name.substring(this.name.indexOf('-') + 1, this.name.lastIndexOf('-')).split('--').join(', ')
+        } else {
+          this.userId = channel.user_id
+          this.isAway = channel.is_away
         }
         break
     }

--- a/lib/service/slack/slack-user.js
+++ b/lib/service/slack/slack-user.js
@@ -4,6 +4,11 @@ class SlackUser extends User {
   constructor(member) {
     super(member.id, member.name, member.profile.image_72)
     this.isBot = member.is_bot
+    this.isAway = true
+  }
+
+  setAway(isAway) {
+    this.isAway = isAway
   }
 }
 

--- a/lib/view/channel-item.js
+++ b/lib/view/channel-item.js
@@ -8,6 +8,8 @@ const DISABLED_COLOR = '#888888'
 const HOVER_BACKGROUND = '#2B2E3B'
 const SELECTED_BACKGROUND = '#6798A2'
 const PADDING = 5
+const DM_PADDING = 18
+const STATUS_INDICATOR_RADIUS = 4
 
 const defaultFont = gui.Font.default()
 const UNREAD_FONT = gui.Font.create(defaultFont.getName(),
@@ -21,6 +23,7 @@ class ChannelItem {
     this.channel = channel
     this.subscription = {
       onUpdateReadState: channel.onUpdateReadState.add(this.update.bind(this)),
+      onUpdateAwayState: channel.onUpdateAwayState.add(this.update.bind(this)),
     }
 
     if (channel.type === 'channel')
@@ -49,6 +52,7 @@ class ChannelItem {
 
   unload() {
     this.subscription.onUpdateReadState.detach()
+    this.subscription.onUpdateAwayState.detach()
   }
 
   select() {
@@ -71,6 +75,7 @@ class ChannelItem {
 
   draw(view, painter, dirty) {
     const bounds = view.getBounds()
+    const padding = this.channel.type === 'dm' ? DM_PADDING : PADDING
     const attributes = {color: NORMAL_COLOR, valign: 'center'}
     // Background color.
     if (this.isSelected) {
@@ -91,8 +96,21 @@ class ChannelItem {
       attributes.font = UNREAD_FONT
       attributes.color = SELECTED_COLOR
     }
-    const textRect = Object.assign(bounds, {x: PADDING, y: 0})
+    const textRect = Object.assign(bounds, {x: padding, y: 0})
     painter.drawText(this.title, textRect, attributes)
+    // Presence indicator
+    if (this.channel.type === 'dm' && !this.channel.isMultiParty) {
+      painter.setFillColor(attributes.color)
+      painter.arc({
+        x: bounds.x - (DM_PADDING / 2),
+        y: (bounds.height / 2) + (STATUS_INDICATOR_RADIUS / 2) - 1,
+      }, STATUS_INDICATOR_RADIUS - (this.channel.isAway ? 0.5 : 0), 0, 360)
+      if (this.channel.isAway)
+        painter.stroke()
+      else {
+        painter.fill()
+      }
+    }
   }
 
   click(view, event) {


### PR DESCRIPTION
- Denormalized `isAway` to save having to dig through channel/member information on render
- [The docs](https://slackapi.github.io/node-slack-sdk/rtm_api#subscribing-to-presence-updates) say `batch_presence_aware` provides an array of user IDs, but all I could get out of it were single event objects.

Toggling status from another device:

![screenshot](https://i.imgur.com/XMpSAZY.gif)