### PR TITLE
Context menu for links

### DIFF
--- a/lib/service/slack/message-parser.js
+++ b/lib/service/slack/message-parser.js
@@ -98,7 +98,7 @@ async function parseLinks(account, text) {
     } else if (content.startsWith('@')) {
       return await parseAt(account, content.substr(1))
     } else {
-      return `<a href="#" onclick="wey.openLink('${content}'); return false">${display}</a>`
+      return `<a href="#" onclick="wey.openLink('${content}'); return false" oncontextmenu="wey.openLinkContextMenu('${content}'); return false">${display}</a>`
     }
   })
 }

--- a/lib/service/slack/message-parser.js
+++ b/lib/service/slack/message-parser.js
@@ -72,7 +72,7 @@ function parseReference(content, display) {
 
 function parseChannel(account, id, display) {
   const domain = account.getDomain()
-  const archiveLink = `https://${domain}.slack.com/archives/${id}`;
+  const archiveLink = `https://${domain}.slack.com/archives/${id}`
   return `<a href="#" onclick="wey.openChannel('${id}'); return false" oncontextmenu="wey.openLinkContextMenu('${archiveLink}'); return false">#${display}</a>`
 }
 

--- a/lib/service/slack/message-parser.js
+++ b/lib/service/slack/message-parser.js
@@ -70,8 +70,10 @@ function parseReference(content, display) {
     return display
 }
 
-function parseChannel(id, display) {
-  return `<a href="#" onclick="wey.openChannel('${id}'); return false">#${display}</a>`
+function parseChannel(account, id, display) {
+  const domain = account.getDomain()
+  const archiveLink = `https://${domain}.slack.com/archives/${id}`;
+  return `<a href="#" onclick="wey.openChannel('${id}'); return false" oncontextmenu="wey.openLinkContextMenu('${archiveLink}'); return false">#${display}</a>`
 }
 
 async function parseAt(account, id) {
@@ -94,7 +96,7 @@ async function parseLinks(account, text) {
     if (content.startsWith('!')) {
       return parseReference(content, display)
     } else if (content.startsWith('#')) {
-      return parseChannel(content.substr(1), display)
+      return parseChannel(account, content.substr(1), display)
     } else if (content.startsWith('@')) {
       return await parseAt(account, content.substr(1))
     } else {

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -125,6 +125,7 @@ class SlackAccount extends Account {
     // Update current team information.
     const {team} = await this.rtm.webClient.team.info()
     this.icon = await imageStore.getImage('team', team.id, team.icon.image_132)
+    this.domain = team.domain
     this.onUpdateInfo.dispatch(this)
     // Fetch users.
     // TODO We need a better policy for users cache.
@@ -281,6 +282,10 @@ class SlackAccount extends Account {
         break
     }
     return ret.sort(compareChannel)
+  }
+
+  getDomain() {
+    return this.domain || null
   }
 }
 

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -43,6 +43,7 @@ class ChatBox {
     this.browser.setBindingName('wey')
     this.browser.addBinding('ready', this.ready.bind(this))
     this.browser.addBinding('openLink', this.openLink.bind(this))
+    this.browser.addBinding('openLinkContextMenu', this.openLinkContextMenu.bind(this))
     this.browser.addBinding('openChannel', this.openChannel.bind(this))
     this.view.addChildView(this.browser)
 
@@ -173,6 +174,26 @@ class ChatBox {
 
   openLink(link) {
     opn(link)
+    this.menu = null
+  }
+
+  copyLink(link) {
+    this.linkStore = gui.TextEdit.create()
+    this.linkStore.setText(link)
+    this.linkStore.selectAll()
+    this.linkStore.cut()
+    this.linkStore = null
+    this.menu = null
+  }
+
+  openLinkContextMenu(link) {
+    if (!this.menu) {
+      this.menu = gui.Menu.create([
+        { label: 'Copy Link', onClick: this.copyLink.bind(this, link)},
+        { label: 'Open Link', onClick: this.openLink.bind(this, link)},
+      ])
+    }
+    this.menu.popup()
   }
 
   openChannel(channel) {


### PR DESCRIPTION
Adds a context menu to external & channel links
- Fixes https://github.com/yue/wey/issues/30, maybe
- I could only find copy-to-clipboard functionality in Yue's `TextEdit` component, so I'm using a temp. component to handle the copying. Maybe there's a better way?
- It looks like link parsing is buggy in general. Due to the parsing order, special characters in links (and their `onclick` attribute values) are often replaced with tags from the regex rulesets. So, `param=*_-_-3~03n*` becomes something like `param=--3~03n`. Fixing that's probably outside the scope of this PR.

![screenshot](https://i.imgur.com/LMdkhk7.png)