### PR TITLE
Close DMs

### DIFF
--- a/lib/model/account.js
+++ b/lib/model/account.js
@@ -26,6 +26,7 @@ class Account {
     this.onAddChannel = new Signal()
     this.onRemoveChannel = new Signal()
     this.onOpenDM = new Signal()
+    this.onCloseDM = new Signal()
 
     accountManager.addAccount(this)
   }

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -78,11 +78,13 @@ class SlackAccount extends Account {
 
     this.rtm.on('im_open', this.openDM.bind(this))
 
+    this.rtm.on('im_close', this.closeDM.bind(this))
+    this.rtm.on('group_close', this.closeDM.bind(this))
+
     this.rtm.on('channel_archive', this.leaveChannel.bind(this))
     this.rtm.on('channel_deleted', this.leaveChannel.bind(this))
     this.rtm.on('channel_left', this.leaveChannel.bind(this))
     this.rtm.on('group_archive', this.leaveChannel.bind(this))
-    this.rtm.on('group_close', this.leaveChannel.bind(this))
     this.rtm.on('group_left', this.leaveChannel.bind(this))
 
     this.rtm.on('presence_change', this.handlePresenceChange.bind(this))
@@ -117,6 +119,10 @@ class SlackAccount extends Account {
 
   async join(channel) {
     await this.rtm.webClient.conversations.join({channel: channel.id})
+  }
+
+  async close(channel) {
+    await this.rtm.webClient.conversations.close({channel: channel.id})
   }
 
   async leave(channel) {
@@ -258,6 +264,14 @@ class SlackAccount extends Account {
     const channel = new SlackChannel(this, 'dm', event)
     this.dms.unshift(channel)
     this.onOpenDM.dispatch(0, channel)
+  }
+
+  async closeDM(event) {
+    const index = this.dms.findIndex((c) => c.id == event.channel)
+    if (index === -1)
+      return
+    this.onCloseDM.dispatch(index, this.dms[index])
+    this.dms.splice(index, 1)
   }
 
   findUserById(id) {

--- a/lib/view/channel-exit.js
+++ b/lib/view/channel-exit.js
@@ -1,0 +1,49 @@
+const gui = require('gui')
+
+const NORMAL_COLOR = '#C1C2C6'
+const HOVER_COLOR = '#FFFFFF'
+const PADDING = 10
+
+const EXIT_RADIUS = 7
+const EXIT_X_HEIGHT = 5
+
+class ChannelExit {
+  constructor() {
+    this.view = gui.Container.create()
+    this.view.setMouseDownCanMoveWindow(false)
+    this.view.setStyle({
+      position: 'absolute',
+      height: 25,
+      width: 16,
+      right: 10,
+    })
+    this.view.onDraw = this.draw.bind(this)
+
+    this.hover = false
+    this.view.onMouseEnter = () => {
+      this.hover = true
+      this.view.schedulePaint()
+    }
+    this.view.onMouseLeave = () => {
+      this.hover = false
+      this.view.schedulePaint()
+    }
+  }
+
+  draw(view, painter, dirty) {
+    const bounds = view.getBounds()
+    const xPos = EXIT_RADIUS + 1;
+    const arcPos = {x: xPos, y: bounds.height / 2}
+    painter.setStrokeColor(this.hover ? HOVER_COLOR : NORMAL_COLOR)
+    painter.beginPath()
+    painter.setLineWidth(1)
+    painter.arc(arcPos, EXIT_RADIUS, 0, 2 * Math.PI)
+    painter.moveTo({x: xPos - (EXIT_X_HEIGHT / 2), y: PADDING})
+    painter.lineTo({x: xPos + (EXIT_X_HEIGHT / 2), y: PADDING + EXIT_X_HEIGHT})
+    painter.moveTo({x: xPos - (EXIT_X_HEIGHT / 2), y: PADDING + EXIT_X_HEIGHT})
+    painter.lineTo({x: xPos + (EXIT_X_HEIGHT / 2), y: PADDING})
+    painter.stroke()
+  }
+}
+
+module.exports = ChannelExit

--- a/lib/view/channel-item.js
+++ b/lib/view/channel-item.js
@@ -1,6 +1,7 @@
 const gui = require('gui')
 
 const ChatWindow = require('./chat-window')
+const ChannelExit = require('./channel-exit')
 
 const NORMAL_COLOR = '#C1C2C6'
 const SELECTED_COLOR = '#FFFFFF'
@@ -40,13 +41,23 @@ class ChannelItem {
     this.view.onDraw = this.draw.bind(this)
     this.view.onMouseEnter = () => {
       this.hover = true
+      if (this.channelExit)
+        this.channelExit.view.setVisible(true)
       this.view.schedulePaint()
     }
     this.view.onMouseLeave = () => {
       this.hover = false
+      if (this.channelExit)
+        this.channelExit.view.setVisible(false)
       this.view.schedulePaint()
     }
     this.view.onMouseUp = this.click.bind(this)
+    if (this.channel.type === 'dm') {
+      this.channelExit = new ChannelExit()
+      this.channelExit.view.setVisible(false)
+      this.channelExit.view.onMouseUp = this.clickExit.bind(this)
+      this.view.addChildView(this.channelExit.view)
+    }
   }
 
   unload() {
@@ -153,9 +164,21 @@ class ChannelItem {
     }
   }
 
+  clickExit(view, event) {
+    if (event.button === 1)
+      this.close()
+    return true
+  }
+
   popup() {
     const bounds = this.parent.mainWindow.chatBox.view.getBounds()
     new ChatWindow(this.parent.account, this.channel, bounds)
+  }
+
+  close() {
+    this.disabled = true
+    this.update()
+    this.parent.account.close(this.channel)
   }
 
   leave() {

--- a/lib/view/channels-panel.js
+++ b/lib/view/channels-panel.js
@@ -50,6 +50,7 @@ class ChannelsPanel {
       this.subscription.onAddChannel.detach()
       this.subscription.onRemoveChannel.detach()
       this.subscription.onOpenDM.detach()
+      this.subscription.onCloseDM.detach()
       this.subscription = null
     }
     this.unloadChannels()
@@ -68,6 +69,7 @@ class ChannelsPanel {
       onAddChannel: account.onAddChannel.add(this.addChannel.bind(this)),
       onRemoveChannel: account.onRemoveChannel.add(this.removeChannel.bind(this)),
       onOpenDM: account.onOpenDM.add(this.openDM.bind(this)),
+      onOpenDM: account.onCloseDM.add(this.closeDM.bind(this)),
     }
     this.accountInfoPanel.loadAccount(account)
     this.loadChannels()
@@ -132,6 +134,15 @@ class ChannelsPanel {
 
   openDM(index, channel) {
     this.addChannel(index + this.account.channels.length + 2, channel)
+  }
+
+  closeDM(index, channel) {
+    const dmIndex = index + this.account.channels.length
+    this.channelsList.removeChildView(this.channelItems[dmIndex].view)
+    this.channelItems.splice(dmIndex, 1)
+    this.updateSize()
+    if (this.selectedChannelItem.channel === channel)
+      this.selectGeneralChannel()
   }
 
   updateSize() {


### PR DESCRIPTION
- Adds the 'close channel' icon + functionality for DMs (im + mpim)
- Fixes `group_close` binding -- was pointing at the wrong index and removing channel, not DM

I think `group_open` & co. are buggy as well, new groups are being added to the channels list, and new single-party DMs either error out or show up blank -- might be related to https://github.com/yue/wey/issues/34?

![screenshot](https://i.imgur.com/j9MvAZG.gif)