### PR TITLE
Channel Info/Actions Header Section

### DIFF
--- a/lib/view/action-panel.js
+++ b/lib/view/action-panel.js
@@ -1,0 +1,70 @@
+const gui = require('gui')
+const slackTheme = require('./theme/slack/global')
+
+const CHANNEL_TITLE_FONT = gui.Font.default().derive(4, 'bold', 'normal')
+const CHANNEL_TITLE_PADDING = 20
+
+class ActionPanel {
+  constructor(mainWindow) {
+    this.mainWindow = mainWindow
+
+    this.channel = null
+    this.channelTitle = ''
+
+    this.view = gui.Container.create()
+    this.view.setStyle({height: '72px'})
+    this.view.setBackgroundColor('#FFFFFF')
+    this.view.onDraw = this.draw.bind(this)
+  }
+
+  unload() {
+    if (this.channel)
+      this.channel = null
+  }
+
+  async loadChannel(account, channel) {
+    this.channel = channel
+    if (channel.type === 'channel')
+      this.channelTitle = (channel.isPrivate ? 'θ' : '#') + ' ' + channel.name
+    else
+      this.channelTitle = channel.name
+
+    this.update()
+  }
+
+  update() {
+    this.view.schedulePaint()
+  }
+
+  draw(view, painter, dirty) {
+    const bounds = view.getBounds()
+    if (this.channel)
+      this.drawChannelTitle(painter, bounds)
+    this.drawBottomBorder(painter, bounds)
+  }
+
+  drawChannelTitle(painter, bounds) {
+    const attributes = {
+      color: slackTheme.PRIMARY_FONT_COLOR,
+      font: CHANNEL_TITLE_FONT,
+    }
+    const textRect = {
+      x: CHANNEL_TITLE_PADDING,
+      y: CHANNEL_TITLE_PADDING,
+      width: bounds.width,
+      height: bounds.height,
+    }
+    painter.drawText(this.channelTitle, textRect, attributes)
+  }
+
+  drawBottomBorder(painter, bounds) {
+    painter.setStrokeColor(slackTheme.LIGHT_BORDER_COLOR)
+    painter.beginPath()
+    painter.setLineWidth(2)
+    painter.moveTo({x: 0, y: bounds.height})
+    painter.lineTo({x: bounds.width, y: bounds.height})
+    painter.stroke()
+  }
+}
+
+module.exports = ActionPanel

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -4,6 +4,7 @@ const gui = require('gui')
 const opn = require('opn')
 const fileUrl = require('file-url')
 
+const slackTheme = require('./theme/slack/global')
 const handlebars = require('./chat/handlebars')
 const accountManager = require('../controller/account-manager')
 
@@ -48,6 +49,7 @@ class ChatBox {
     this.view.addChildView(this.browser)
 
     this.replyBox = gui.Container.create()
+    this.replyBox.setBackgroundColor(slackTheme.LIGHT_BORDER_COLOR)
     this.replyBox.setStyle({padding: 5})
     this.view.addChildView(this.replyBox)
 

--- a/lib/view/main-window.js
+++ b/lib/view/main-window.js
@@ -3,6 +3,7 @@ const gui = require('gui')
 const AccountsPanel = require('./accounts-panel')
 const ChannelsPanel = require('./channels-panel')
 const ChatBox = require('./chat-box')
+const ActionPanel = require('./action-panel')
 const ChannelsSearcher = require('./channels-searcher')
 
 const accountManager = require('../controller/account-manager')
@@ -19,8 +20,15 @@ class MainWindow {
     contentView.addChildView(this.accountsPanel.view)
     this.channelsPanel = new ChannelsPanel(this)
     contentView.addChildView(this.channelsPanel.view)
+
+    this.chatContentView = gui.Container.create()
+    this.chatContentView.setStyle({flexDirection: 'column', flex: 1})
+    contentView.addChildView(this.chatContentView)
+    this.actionPanel = new ActionPanel(this)
+    this.chatContentView.addChildView(this.actionPanel.view)
     this.chatBox = new ChatBox(this)
-    contentView.addChildView(this.chatBox.view)
+    this.chatContentView.addChildView(this.chatBox.view)
+
     this.channelsSearcher = new ChannelsSearcher(this)
     this.channelsSearcher.view.setVisible(false)
     contentView.addChildView(this.channelsSearcher.view)
@@ -65,11 +73,13 @@ class MainWindow {
     this.accountsPanel.unload()
     this.channelsPanel.unload()
     this.chatBox.unload()
+    this.actionPanel.unload()
     this.channelsSearcher.unload()
   }
 
   setLoading() {
     this.channelsSearcher.view.setVisible(false)
+    this.actionPanel.view.setVisible(false)
     this.chatBox.view.setVisible(true)
     this.chatBox.setLoading()
   }
@@ -101,7 +111,9 @@ class MainWindow {
     if (this.channelsPanel.selectedChannelItem ||
         this.selectedAccount !== account)  // may switch channel before await
       return
+    this.chatContentView.setVisible(false)
     this.chatBox.view.setVisible(false)
+    this.actionPanel.view.setVisible(false)
     this.channelsSearcher.loadChannels(account, channels)
   }
 
@@ -142,8 +154,11 @@ class MainWindow {
 
   loadChannel(account, channel) {
     this.channelsSearcher.unload()
+    this.chatContentView.setVisible(true)
     this.chatBox.view.setVisible(true)
     this.chatBox.loadChannel(account, channel)
+    this.actionPanel.view.setVisible(true)
+    this.actionPanel.loadChannel(account, channel)
     require('../controller/config-store').serialize()
   }
 }

--- a/lib/view/theme/slack/global.js
+++ b/lib/view/theme/slack/global.js
@@ -1,0 +1,4 @@
+module.exports = {
+  PRIMARY_FONT_COLOR: '#2C2D30',
+  LIGHT_BORDER_COLOR: '#E5E5E5',
+}


### PR DESCRIPTION
I have no idea what to call this thing, feel free to rename it. Will need to add a lot more stuff (channel settings, details, topic, members, search, activity, starred items, etc.).

Feels like `lib/view` is getting more slack-specific, wonder how service-specific view isolation is going to play out.

![screenshot](https://i.imgur.com/1DXYxgd.gif)