### PR TITLE
Add ability to add multiple Slack accounts from tokens without closing login window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 /node_modules/
 /out/
 /yode/
+.idea/*

--- a/lib/service/slack/index.js
+++ b/lib/service/slack/index.js
@@ -29,8 +29,8 @@ class SlackService extends Service {
     return new SlackAccount(this, null, null, config)
   }
 
-  loginWithToken(token) {
-    this.loginWindow.setContentView(gui.Label.create('Loading...'))
+  loginWithToken(token, button) {
+    button.setTitle("Loading...")
     const rtm = new RTMClient(token)
     require('./private-apis').extend(rtm)
     rtm.once('unable_to_rtm_start', (error) => {
@@ -38,8 +38,10 @@ class SlackService extends Service {
       this.loginWindow.close()
     })
     rtm.once('authenticated', (data) => {
-      this.loginWindow.close()
       new SlackAccount(this, data, rtm)
+      button.setVisible(false)
+      this.adujstLoginWindowSize()
+
     })
     rtm.start({batch_presence_aware: true})
   }
@@ -163,7 +165,7 @@ class SlackService extends Service {
         width: '100%',
         marginTop: 10,
       })
-      button.onClick = this.loginWithToken.bind(this, team.token)
+      button.onClick = this.loginWithToken.bind(this, team.token, button)
       this.loginWindow.getContentView().addChildView(button)
     }
     fetchButton.setVisible(false)


### PR DESCRIPTION
I added the ability to add multiple slack accounts, from tokens, without the login window closing. 

[A demonstration can be found here](https://i.imgur.com/xHXdnmP.gif).

Let me know if the way I hide the button is the best way - I tried looking at the Yue documentation, but I could not find how to actually destruct an item. I'm assuming once the Login Window is called the button gets destroyed, but I'm not sure, and would like to be as memory efficient as possible.

Let me know if you have any questions. 