### PR TITLE
feat: render username with user's color

### DIFF
--- a/lib/service/slack/slack-user.js
+++ b/lib/service/slack/slack-user.js
@@ -4,6 +4,7 @@ class SlackUser extends User {
   constructor(member) {
     const displayName = member.profile.display_name
     super(member.id, displayName ? displayName : member.name, member.profile.image_72)
+    this.color = member.color
     this.isBot = member.is_bot
     this.isAway = true
   }

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -29,7 +29,7 @@
   <div class="content">
     {{#unless message.isFolded}}
     <div class="sender">
-      <div class="name">{{message.user.name}}</div>
+      <div class="name" style="color: #{{message.user.color}}">{{message.user.name}}</div>
       <div class="time">{{message.shortTime}}</div>
     </div>
     {{/unless}}


### PR DESCRIPTION
- render username using user's color, mimic slack client.

![image](https://user-images.githubusercontent.com/627278/39292679-175333aa-4961-11e8-88c4-dd3da6908419.png)
