### PR TITLE
Add @mentions in chat-box

### DIFF
--- a/lib/model/account.js
+++ b/lib/model/account.js
@@ -2,6 +2,8 @@ const Signal = require('mini-signals')
 
 const accountManager = require('../controller/account-manager')
 
+const MENTION_SEARCH_LIMIT = 5
+
 class Account {
   constructor(service, config) {
     this.service = service
@@ -16,6 +18,7 @@ class Account {
     this.currentUserId = null
     this.currentUserName = null
     this.users = {}
+    this.usersNameMap = {}
     this.isRead = true
     this.mentions = 0
 
@@ -56,9 +59,68 @@ class Account {
     return this.dms.find((c) => c.userId === id)
   }
 
+  findUserById(id) {
+    return this.users[id]
+  }
+
+  // Find a partial match for users
+  findUsersByName(name) {
+    const users = []
+    let exactIndex = null
+    const lowerName = name.toLowerCase()
+    const firstLetter = lowerName[0]
+    const letterUsers = this.usersNameMap[firstLetter]
+
+    if (letterUsers) {
+      for (const user of letterUsers) {
+        const userLowerName = user.name.toLowerCase()
+        const isExact = userLowerName === lowerName
+
+        if (isExact || userLowerName.indexOf(lowerName) === 0) {
+          users.push(user)
+
+          if (isExact)
+            exactIndex = users.length - 1
+
+          if (users.length === MENTION_SEARCH_LIMIT)
+            break
+        }
+      }
+    }
+
+    return { users, exactIndex }
+  }
+
   computeReadState() {
     const compute = (r, c) => { return (c.isRead || c.isMuted) ? r : false }
     return this.channels.reduce(compute, this.dms.reduce(compute, true))
+  }
+
+  // Save user for ID lookup and @mention name lookup
+  saveUser(newUser, doSort = false) {
+    const oldUser = this.users[newUser.id]
+    const newFirstLetter = newUser.name[0].toLowerCase()
+
+    if (oldUser && oldUser.name !== newUser.name) {
+      // If user name changed, delete old reference
+      const oldFirstLetter = oldUser.name[0].toLowerCase()
+      const index = this.usersNameMap[oldFirstLetter].indexOf(oldUser)
+
+      this.usersNameMap[oldFirstLetter].splice(index, 1)
+    }
+
+    if (!this.usersNameMap[newFirstLetter])
+      this.usersNameMap[newFirstLetter] = []
+
+    // Segregate users by first letter so the lookup is smaller in big groups
+    // @todo optimize this more, since alphabetical distribution is not even
+    this.usersNameMap[newFirstLetter].push(newUser)
+    this.users[newUser.id] = newUser
+
+    if (doSort)
+      this.sortUsers(newFirstLetter)
+
+    return newUser
   }
 
   setReadState(read) {
@@ -66,6 +128,20 @@ class Account {
       this.isRead = read
       this.onUpdateReadState.dispatch(this.isRead)
       accountManager.onUpdateReadState.dispatch(accountManager.computeReadState())
+    }
+  }
+
+  // Async so it is non-blocking in saveUser
+  async sortUsers(index = null) {
+    const indexes = index ? [index] : Object.keys(this.usersNameMap)
+
+    for (const firstLetter of indexes) {
+      if (this.users[firstLetter]) {
+        if (this.users[firstLetter].length)
+          this.users[firstLetter] = this.users[firstLetter].sort(localeSort)
+        else
+          delete this.users[firstLetter]
+      }
     }
   }
 

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -10,6 +10,10 @@ const SlackUser = require('./slack-user')
 
 const imageStore = require('../../controller/image-store')
 
+function localeSort(userA, userB) {
+  return userA.name.localeCompare(userB.name)
+}
+
 function compareChannel(a, b) {
   const nameA = a.name.toUpperCase()
   const nameB = b.name.toUpperCase()
@@ -110,8 +114,11 @@ class SlackAccount extends Account {
     // Fetch users.
     // TODO We need a better policy for users cache.
     const {members} = await this.rtm.webClient.users.list()
-    for (const m of members)
-      this.users[m.id] = new SlackUser(this, m)
+    for (const m of members) {
+      // Don't handle deleted users unless we specifically need them in fetchUser
+      if (m.deleted !== true)
+        this.saveUser(m)
+    }
     // Current user.
     this.currentUserId = data.self.id
     this.currentUserName = data.self.name
@@ -119,6 +126,8 @@ class SlackAccount extends Account {
     await this.updateEmoji()
     // Fetch channels.
     await this.updateChannels()
+    // Sort users' names alphabetically for @mention
+    await this.sortUsers()
   }
 
   async updateEmoji() {
@@ -346,8 +355,9 @@ class SlackAccount extends Account {
     this.updatePresenceSubscription()
   }
 
-  findUserById(id) {
-    return this.users[id]
+  // Save user for ID lookup and @mention name lookup
+  saveUser(member, doSort = false) {
+    return super.saveUser(new SlackUser(this, member), doSort)
   }
 
   async fetchUser(id, isBot) {
@@ -365,7 +375,7 @@ class SlackAccount extends Account {
       const {user} = await this.rtm.webClient.users.info({user: id})
       member = user
     }
-    return this.users[id] = new SlackUser(this, member)
+    return this.saveUser(member, true)
   }
 
   async listChannels(options, filter) {

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -35,6 +35,13 @@ const pageTemplate = handlebars.compile(fs.readFileSync(path.join(__dirname, 'ch
 // (call realpathSync to keep compatibility with ASAR.)
 const loadingUrl = fileUrl(fs.realpathSync(path.join(__dirname, 'chat', 'loading.html')))
 
+function getMenuCallback(userId, replyEntry, deleteFrom, deleteTo) {
+  return menuItem => {
+    replyEntry.deleteRange(deleteFrom, deleteTo)
+    replyEntry.insertText(`<@${userId}>`)
+  };
+}
+
 class ChatBox {
   constructor(mainWindow) {
     this.mainWindow = mainWindow
@@ -88,6 +95,8 @@ class ChatBox {
     this.replyEntry.setStyle({height: this.minReplyEntryHeight})
     // Handle input events.
     this.replyEntry.onTextChange = this.adjustEntryHeight.bind(this)
+    // @todo Yue bug: Use onKeyDown instead, but yue only triggers for modifier keys on MacOS at the moment
+    this.replyEntry.onKeyUp = this.onKeyUp.bind(this)
     this.replyEntry.shouldInsertNewLine = this.handleEnter.bind(this)
     this.replyBox.addChildView(this.replyEntry)
 
@@ -277,6 +286,55 @@ class ChatBox {
           this.isSendingReply = false
         })
     return false
+  }
+
+  onKeyUp(replyEntry, keyEvent) {
+    // Only handle TAB key
+    if (keyEvent.key !== 'Tab')
+      return
+
+    // Only run if no text selected
+    const [pos, posB] = replyEntry.getSelectionRange()
+    if (pos !== posB || pos < 1)
+      return
+
+    // Looking for @mention only
+    const str = replyEntry.getTextInRange(0, pos)
+    const match = str.match(/(?:^|\s+)(@[^@\r\n\t]+)\t$/)
+    if (!match)
+      return
+
+    const name = match[1].substr(1)
+
+    const { users, exactIndex } = this.messageList.account.findUsersByName(name)
+
+    if (users.length === 1) {
+      // Delete text and tab, insert user
+      replyEntry.deleteRange(pos - name.length - 2, pos)
+      replyEntry.insertText(`<@${users[0].id}>`)
+      return true
+    } else {
+      // @todo Yue bug: Hack for the fact that this runs onKeyUp instead of onKeyDown, delete tab
+      replyEntry.deleteRange(pos - 1, pos)
+    }
+
+    if (users.length === 0)
+      return
+
+    // Add exact match to top of results
+    if (exactIndex !== null)
+      users.unshift(users.splice(exactIndex, 1)[0])
+
+    // @todo Yue feature: Make this menu appear at the caret instead of at the cursor
+    const menu = gui.Menu.create(
+      users.map(user => ({
+        label: `@${user.name}`,
+        onClick: getMenuCallback(user.id, replyEntry, pos - name.length - 2, pos - 1)
+      }))
+    )
+    menu.popup()
+
+    return true
   }
 }
 


### PR DESCRIPTION
Using `onKeyUp`, if key is `Tab`, and `@` exists before the caret, use that
entire string to look up a user by their `name`. ie. `@foo bar` will find user `Foo Bar`, `@foo` will find both `Foo Bar` and `fooman`.

Also removes initializing `deleted` users in `SlackAccount.ready`.

This depends on https://github.com/yue/yue/pull/44 to actually work, but this code should not break anything without it merged (since the selected index will be -1 to -1).

Known issues:
- `View.onKeyDown` is only triggering for modifier keys (MacOS only?). This
  requires a hack that we have to delete the inserted tab instead of preventing
  preventing it entirely.
- `Menu.popup()` does not allow you to specify a location, so the users list
  appears at the mouse cursor, instead of the text caret.
- There is no way to show the "pretty" user name at the moment. In a future
  version, we could potentially show the username as usual, while keeping
  track of the its string position, then render a highlight on top -- and
  finally re-process the message on send to inject the stored `<@id>`.
- This does not yet implement UAX44-LM3, so if you want to look up a user named `ère`, you'll have to type `@èr` not `@er`.