### PR TITLE
Mentions, reactions, cleanup, optimizations

### DIFF
--- a/lib/controller/config-store.js
+++ b/lib/controller/config-store.js
@@ -22,7 +22,7 @@ function getConfigDir(name) {
       else
         return path.join(os.homedir(), '.config', name)
     default:
-      throw new Error('Unkown platform')
+      throw new Error('Unknown platform')
   }
 }
 

--- a/lib/controller/image-store.js
+++ b/lib/controller/image-store.js
@@ -18,7 +18,7 @@ function getCacheDir(name) {
       else
         return path.join(os.homedir(), '.cache', name)
     default:
-      throw new Error('Unkown platform')
+      throw new Error('Unknown platform')
   }
 }
 

--- a/lib/model/account.js
+++ b/lib/model/account.js
@@ -2,6 +2,8 @@ const Signal = require('mini-signals')
 
 const accountManager = require('../controller/account-manager')
 
+const MENTION_SEARCH_LIMIT = 5
+
 class Account {
   constructor(service, config) {
     this.service = service
@@ -16,6 +18,7 @@ class Account {
     this.currentUserId = null
     this.currentUserName = null
     this.users = {}
+    this.usersNameMap = {}
     this.isRead = true
     this.mentions = 0
 
@@ -56,9 +59,68 @@ class Account {
     return this.dms.find((c) => c.userId === id)
   }
 
+  findUserById(id) {
+    return this.users[id]
+  }
+
+  // Find a partial match for users
+  findUsersByName(name) {
+    const users = []
+    let exactIndex = null
+    const lowerName = name.toLowerCase()
+    const firstLetter = lowerName[0]
+    const letterUsers = this.usersNameMap[firstLetter]
+
+    if (letterUsers) {
+      for (const user of letterUsers) {
+        const userLowerName = user.name.toLowerCase()
+        const isExact = userLowerName === lowerName
+
+        if (isExact || userLowerName.indexOf(lowerName) === 0) {
+          users.push(user)
+
+          if (isExact)
+            exactIndex = users.length - 1
+
+          if (users.length === MENTION_SEARCH_LIMIT)
+            break
+        }
+      }
+    }
+
+    return { users, exactIndex }
+  }
+
   computeReadState() {
     const compute = (r, c) => { return (c.isRead || c.isMuted) ? r : false }
     return this.channels.reduce(compute, this.dms.reduce(compute, true))
+  }
+
+  // Save user for ID lookup and @mention name lookup
+  saveUser(newUser, doSort = false) {
+    const oldUser = this.users[newUser.id]
+    const newFirstLetter = newUser.name[0].toLowerCase()
+
+    if (oldUser && oldUser.name !== newUser.name) {
+      // If user name changed, delete old reference
+      const oldFirstLetter = oldUser.name[0].toLowerCase()
+      const index = this.usersNameMap[oldFirstLetter].indexOf(oldUser)
+
+      this.usersNameMap[oldFirstLetter].splice(index, 1)
+    }
+
+    if (!this.usersNameMap[newFirstLetter])
+      this.usersNameMap[newFirstLetter] = []
+
+    // Segregate users by first letter so the lookup is smaller in big groups
+    // @todo optimize this more, since alphabetical distribution is not even
+    this.usersNameMap[newFirstLetter].push(newUser)
+    this.users[newUser.id] = newUser
+
+    if (doSort)
+      this.sortUsers(newFirstLetter)
+
+    return newUser
   }
 
   setReadState(read) {
@@ -66,6 +128,20 @@ class Account {
       this.isRead = read
       this.onUpdateReadState.dispatch(this.isRead)
       accountManager.onUpdateReadState.dispatch(accountManager.computeReadState())
+    }
+  }
+
+  // Async so it is non-blocking in saveUser
+  async sortUsers(index = null) {
+    const indexes = index ? [index] : Object.keys(this.usersNameMap)
+
+    for (const firstLetter of indexes) {
+      if (this.users[firstLetter]) {
+        if (this.users[firstLetter].length)
+          this.users[firstLetter] = this.users[firstLetter].sort(localeSort)
+        else
+          delete this.users[firstLetter]
+      }
     }
   }
 

--- a/lib/model/message-list.js
+++ b/lib/model/message-list.js
@@ -11,6 +11,7 @@ class MessageList {
     this.type = type
     this.id = id
     this.messages = []
+    this.messagesById = {}
     this.mentions = 0
 
     // Whether all messages of channel have been read.
@@ -107,6 +108,7 @@ class MessageList {
   clear() {
     this.messagesReady = false
     this.messages = []
+    this.messagesById = {}
   }
 
   hasMessages() {
@@ -117,23 +119,14 @@ class MessageList {
     return this.messages[this.messages.length - 1]
   }
 
-  findMessageIndex(id, timestamp) {
-    if (!this.hasMessages())
-      return -1
-    const date = new Date(timestamp * 1000)
-    for (let i = this.messages.length - 1; i >= 0; --i) {
-      const message = this.messages[i]
-      if (message.id === id)
-        return i
-      if (message.date < date)
-        return -1
-    }
-    return -1
-  }
-
   findMessage(id, timestamp) {
-    const i = this.findMessageIndex(id, timestamp)
-    return i === -1 ? null : this.messages[i]
+    if (this.hasMessages()) {
+      const date = new Date(timestamp * 1000)
+      const message = this.messagesById[id]
+      if (message && message.id === id && message.date >= date)
+        return message
+    }
+    return null
   }
 
   async dispatchMessage(message) {
@@ -175,6 +168,10 @@ class MessageList {
     // splice too often.
     if (this.messages.length > CACHE_MESSAGES_LIMIT) {
       this.messages.splice(0, 50)
+      this.messagesById = this.messages.reduce((map, message) => {
+        map[message.id] = message
+        return map
+      }, {})
       this.messages[0].setDayMarker()
     }
     // Dispatch the message.
@@ -184,20 +181,23 @@ class MessageList {
   deleteMessage(id, timestamp) {
     if (!this.isReceiving)
       return
-    const i = this.findMessageIndex(id, timestamp)
-    if (i !== -1) {
-      this.messages.splice(i, 1)
-      this.onDeleteMessage.dispatch(id, timestamp)
+    const message = this.findMessage(id, timestamp)
+    if (message) {
+      const index = this.messages.indexOf(message)
+      if (index > -1) {
+        this.messages.splice(index, 1)
+        delete this.messagesById[id]
+        this.onDeleteMessage.dispatch(id, timestamp)
+      }
     }
   }
 
   modifyMessage(id, timestamp, modified) {
     if (!this.isReceiving)
       return
-    const i = this.findMessageIndex(id, timestamp)
-    if (i === -1)
+    const original = this.findMessage(id, timestamp)
+    if (!original)
       return
-    const original = this.messages[i]
     // Save old properties.
     const old = Object.assign({}, original)
     // Copy properties, we should NOT assign directly since it would change the
@@ -216,9 +216,10 @@ class MessageList {
     if (!message)
       return
     const existing = message.reactions.find((r) => r.name === reaction.name)
-    if (existing)
-      ++existing.count;
-    else
+    if (existing) {
+      ++existing.count
+      existing.hasCurrentUser = reaction.hasCurrentUser
+    } else
       message.reactions.push(reaction)
     this.onModifyMessage.dispatch(id, message)
   }
@@ -232,10 +233,11 @@ class MessageList {
     const i = message.reactions.findIndex((r) => r.name === reaction.name)
     if (i === -1)
       return
+    message.reactions[i].hasCurrentUser = reaction.hasCurrentUser
     if (--message.reactions[i].count === 0) {
       message.reactions.splice(i, 1)
-      this.onModifyMessage.dispatch(id, message)
     }
+    this.onModifyMessage.dispatch(id, message)
   }
 
   async readMessages() {
@@ -247,7 +249,7 @@ class MessageList {
     const messages = await this.readMessagesPromise
     this.readMessagesPromise = null
     // Concatenate messages.
-    this.messages = this.foldMessages(messages).concat(this.messages)
+    this.saveAndFoldMessages(messages)
     // Update latestTs.
     if (!this.latestTs && this.hasMessages())
       this.latestTs = this.latestMessage().timestamp
@@ -257,8 +259,10 @@ class MessageList {
     // messages.
     if (this.account.status === 'connected')
       this.messagesReady = true
-    else
+    else {
       this.messages = []
+      this.messagesById = {}
+    }
     return this.messages
   }
 
@@ -284,15 +288,16 @@ class MessageList {
   }
 
   // Compute day markers and whether messages should be folded.
-  foldMessages(messages) {
-    for (const i in messages) {
-      if (i == 0) {
+  saveAndFoldMessages(messages) {
+    for (let i = messages.length; i--;) {
+      if (i === 0)
         messages[i].setDayMarker()
-        continue
-      }
-      this.compareMessage(messages[i], messages[i - 1])
+      else
+        this.compareMessage(messages[i], messages[i - 1])
+
+      this.messages.unshift(messages[i])
+      this.messagesById[messages[i].id] = messages[i]
     }
-    return messages
   }
 
   compareMessage(m, pm) {

--- a/lib/model/reaction.js
+++ b/lib/model/reaction.js
@@ -1,8 +1,9 @@
 class Reaction {
-  constructor(name, count, content) {
+  constructor(name, count, content, hasCurrentUser) {
     this.name = name
     this.count = count
     this.content = content
+    this.hasCurrentUser = hasCurrentUser
   }
 }
 

--- a/lib/service/slack/message-parser.js
+++ b/lib/service/slack/message-parser.js
@@ -83,7 +83,7 @@ function parseChannel(account, id, display) {
 async function parseAt(account, id) {
   const user = await account.fetchUser(id)
   if (!user)
-    return `@&lt;unkown user: ${id}&gt;`
+    return `@&lt;unknown user: ${id}&gt;`
   if (id === account.currentUserId)
     return `<span class="broadcast at">@${user.name}</span>`
   else

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -252,6 +252,7 @@ class SlackAccount extends Account {
           break
         const partial = new SlackMessage(this, event.message)
         await partial.fetchPendingInfo(this)
+        original.isThreadParent = partial.isThreadParent
         original.replyCount = partial.replyCount
         original.replyUsers = partial.replyUsers
         // Emit for channel and thread.

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -284,7 +284,19 @@ class SlackAccount extends Account {
     const channel = this.findChannelById(event.item.channel)
     if (!channel)
       return
-    const reaction = new SlackReaction(this, event.reaction, 1)
+
+    const users = []
+    if (event.user === this.currentUserId) {
+      // User just added a react
+      users.push(this.currentUserId)
+    } else {
+      // Did user previously react to this?
+      const message = channel.findMessage(event.item.ts, event.item.ts)
+      if (message && message.reactions && message.reactions.hasCurrentUser)
+        users.push(this.currentUserId)
+    }
+
+    const reaction = new SlackReaction(this, event.reaction, 1, users)
     channel.addReaction(event.item.ts, event.item.ts, reaction)
   }
 
@@ -292,7 +304,16 @@ class SlackAccount extends Account {
     const channel = this.findChannelById(event.item.channel)
     if (!channel)
       return
-    const reaction = new SlackReaction(this, event.reaction, -1)
+
+    const users = []
+    if (event.user !== this.currentUserId) {
+      // Did user previously react to this?
+      const message = channel.findMessage(event.item.ts, event.item.ts)
+      if (message && message.reactions && message.reactions.hasCurrentUser)
+        users.push(this.currentUserId)
+    }
+
+    const reaction = new SlackReaction(this, event.reaction, -1, users)
     channel.removeReaction(event.item.ts, event.item.ts, reaction)
   }
 

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -10,6 +10,10 @@ const SlackUser = require('./slack-user')
 
 const imageStore = require('../../controller/image-store')
 
+function localeSort(userA, userB) {
+  return userA.name.localeCompare(userB.name)
+}
+
 function compareChannel(a, b) {
   const nameA = a.name.toUpperCase()
   const nameB = b.name.toUpperCase()
@@ -110,8 +114,11 @@ class SlackAccount extends Account {
     // Fetch users.
     // TODO We need a better policy for users cache.
     const {members} = await this.rtm.webClient.users.list()
-    for (const m of members)
-      this.users[m.id] = new SlackUser(this, m)
+    for (const m of members) {
+      // Don't handle deleted users unless we specifically need them in fetchUser
+      if (m.deleted !== true)
+        this.saveUser(m)
+    }
     // Current user.
     this.currentUserId = data.self.id
     this.currentUserName = data.self.name
@@ -119,6 +126,8 @@ class SlackAccount extends Account {
     await this.updateEmoji()
     // Fetch channels.
     await this.updateChannels()
+    // Sort users' names alphabetically for @mention
+    await this.sortUsers()
   }
 
   async updateEmoji() {
@@ -346,8 +355,9 @@ class SlackAccount extends Account {
     this.updatePresenceSubscription()
   }
 
-  findUserById(id) {
-    return this.users[id]
+  // Save user for ID lookup and @mention name lookup
+  saveUser(member, doSort = false) {
+    return super.saveUser(new SlackUser(this, member), doSort)
   }
 
   async fetchUser(id, isBot) {
@@ -365,7 +375,7 @@ class SlackAccount extends Account {
       const {user} = await this.rtm.webClient.users.info({user: id})
       member = user
     }
-    return this.users[id] = new SlackUser(this, member)
+    return this.saveUser(member, true)
   }
 
   async listChannels(options, filter) {

--- a/lib/service/slack/slack-message.js
+++ b/lib/service/slack/slack-message.js
@@ -25,7 +25,7 @@ class SlackMessage extends Message {
     if (event.edited && !this.isBot)
       this.isEdited = true
     if (event.reactions)
-      this.reactions = event.reactions.map((r) => new SlackReaction(account, r.name, r.count))
+      this.reactions = event.reactions.map(r => new SlackReaction(account, r.name, r.count, r.users))
     if (event.thread_ts) {
       this.threadId = event.thread_ts
       if (event.thread_ts === event.ts) {

--- a/lib/service/slack/slack-message.js
+++ b/lib/service/slack/slack-message.js
@@ -56,7 +56,7 @@ class SlackMessage extends Message {
       }
       this.user = account.findUserById(userId)
       if (!this.user) {
-        this.user = new User(userId, '<unkown>', '')
+        this.user = new User(userId, '<unknown>', '')
         this.pendingUser = userId
       }
     }

--- a/lib/service/slack/slack-reaction.js
+++ b/lib/service/slack/slack-reaction.js
@@ -11,9 +11,10 @@ function normalizeReactionName(name) {
 }
 
 class SlackReaction extends Reaction {
-  constructor(account, name, count) {
+  constructor(account, name, count, users) {
     name = normalizeReactionName(name)
-    super(name, count, parseEmoji(account, 16, name))
+    const hasCurrentUser = users && users.indexOf(account.currentUserId) > -1
+    super(name, count, parseEmoji(account, 16, name), hasCurrentUser)
   }
 }
 

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -35,6 +35,13 @@ const pageTemplate = handlebars.compile(fs.readFileSync(path.join(__dirname, 'ch
 // (call realpathSync to keep compatibility with ASAR.)
 const loadingUrl = fileUrl(fs.realpathSync(path.join(__dirname, 'chat', 'loading.html')))
 
+function getMenuCallback(userId, replyEntry, deleteFrom, deleteTo) {
+  return menuItem => {
+    replyEntry.deleteRange(deleteFrom, deleteTo)
+    replyEntry.insertText(`<@${userId}>`)
+  };
+}
+
 class ChatBox {
   constructor(mainWindow) {
     this.mainWindow = mainWindow
@@ -88,6 +95,8 @@ class ChatBox {
     this.replyEntry.setStyle({height: this.minReplyEntryHeight})
     // Handle input events.
     this.replyEntry.onTextChange = this.adjustEntryHeight.bind(this)
+    // @todo Yue bug: Use onKeyDown instead, but yue only triggers for modifier keys on MacOS at the moment
+    this.replyEntry.onKeyUp = this.onKeyUp.bind(this)
     this.replyEntry.shouldInsertNewLine = this.handleEnter.bind(this)
     this.replyBox.addChildView(this.replyEntry)
 
@@ -277,6 +286,55 @@ class ChatBox {
           this.isSendingReply = false
         })
     return false
+  }
+
+  onKeyUp(replyEntry, keyEvent) {
+    // Only handle TAB key
+    if (keyEvent.key !== 'Tab')
+      return
+
+    // Only run if no text selected
+    const [pos, posB] = replyEntry.getSelectionRange()
+    if (pos !== posB || pos < 1)
+      return
+
+    // Looking for @mention only
+    const str = replyEntry.getTextInRange(0, pos)
+    const match = str.match(/(?:^|\s+)(@[^@\r\n\t]+)\t$/)
+    if (!match)
+      return
+
+    const name = match[1].substr(1)
+
+    const { users, exactIndex } = this.messageList.account.findUsersByName(name)
+
+    if (users.length === 1) {
+      // Delete text and tab, insert user
+      replyEntry.deleteRange(pos - name.length - 2, pos)
+      replyEntry.insertText(`<@${users[0].id}>`)
+      return true
+    } else {
+      // @todo Yue bug: Hack for the fact that this runs onKeyUp instead of onKeyDown, delete tab
+      replyEntry.deleteRange(pos - 1, pos)
+    }
+
+    if (users.length === 0)
+      return
+
+    // Add exact match to top of results
+    if (exactIndex !== null)
+      users.unshift(users.splice(exactIndex, 1)[0])
+
+    // @todo Yue feature: Make this menu appear at the caret instead of at the cursor
+    const menu = gui.Menu.create(
+      users.map(user => ({
+        label: `@${user.name}`,
+        onClick: getMenuCallback(user.id, replyEntry, pos - name.length - 2, pos - 1)
+      }))
+    )
+    menu.popup()
+
+    return true
   }
 }
 

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -267,7 +267,7 @@ class ChatBox {
     if (gui.Event.isShiftPressed())
       return true
     const message = replyEntry.getText()
-    if (message.length == 0 || !this.messageList || this.isSendingReply)
+    if (message.trim().length == 0 || !this.messageList || this.isSendingReply)
       return false
     replyEntry.setEnabled(false)
     this.isSendingReply = true

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -33,7 +33,10 @@ handlebars.registerHelper('isThreadParent', function(message, options) {
 })
 
 handlebars.registerHelper('replace', function(string, substring, replacement) {
-  return string.replace(substring, replacement)
+  if (string)
+    return (string + '').replace(substring, replacement)
+  console.error('Not a string', string)
+  return string
 })
 
 // Templates for handlebarjs.
@@ -80,6 +83,8 @@ class ChatBox {
     this.browser.addBinding('openLinkContextMenu', this.openLinkContextMenu.bind(this))
     this.browser.addBinding('openChannel', this.openChannel.bind(this))
     this.browser.addBinding('openThread', this.openThread.bind(this))
+    this.browser.addBinding('openReactionMenu', this.openReactionMenu.bind(this))
+    this.browser.addBinding('toggleReaction', this.toggleReaction.bind(this))
     this.view.addChildView(this.browser)
 
     this.replyBox = gui.Container.create()
@@ -241,6 +246,61 @@ class ChatBox {
     linkStore.setText(link)
     linkStore.selectAll()
     linkStore.cut()
+  }
+
+  async toggleReaction(name, channel, timestamp) {
+    const message = this.messageList.findMessage(timestamp, timestamp)
+
+    if (message && message.reactions) {
+      if (message.reactions.find(reaction => reaction.name === name && reaction.hasCurrentUser)) {
+        // @todo This is a hack. Don't fetch directly from RTM SDK here!
+        await this.messageList.account.rtm.webClient.reactions.remove({
+          name,
+          channel,
+          timestamp
+        })
+        return
+      }
+    }
+
+    // @todo This is a hack. Don't fetch directly from RTM SDK here!
+    await this.messageList.account.rtm.webClient.reactions.add({
+      name,
+      channel,
+      timestamp
+    })
+  }
+
+  async openReactionMenu(channel, messageId) {
+    // @todo This is a hack. Don't fetch directly from RTM SDK here!
+    const customEmojis = await this.messageList.account.rtm.webClient.emoji.list()
+    const message = this.messageList.findMessage(messageId, messageId)
+
+    // Push existing reactions to top
+    const mountedEmojis = {}
+    const emojis = (message.reactions || []).map(reaction => {
+      mountedEmojis[reaction.name] = true
+
+      return {
+        type: 'checkbox',
+        label: reaction.name,
+        checked: reaction.hasCurrentUser,
+        onClick: el => this.toggleReaction(reaction.name, channel, messageId)
+      }
+    })
+
+    // Show remaining emojis (but no duplicates)
+    for (const name of Object.keys(customEmojis.emoji).sort()) {
+      if (!mountedEmojis[name]) {
+        emojis.push({
+          type: 'checkbox',
+          label: name,
+          onClick: el => this.toggleReaction(name, channel, messageId)
+        })
+      }
+    }
+
+    gui.Menu.create(emojis).popup()
   }
 
   openLinkContextMenu(link) {

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -32,6 +32,10 @@ handlebars.registerHelper('isThreadParent', function(message, options) {
     return options.inverse(this)
 })
 
+handlebars.registerHelper('replace', function(string, substring, replacement) {
+  return string.replace(substring, replacement)
+})
+
 // Templates for handlebarjs.
 const messageHtml = fs.readFileSync(path.join(__dirname, 'chat', 'message.html')).toString()
 handlebars.registerPartial('messagePartial', messageHtml)

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -18,8 +18,15 @@ handlebars.registerHelper('isFirstUnread', function(messageList, message, option
     return options.inverse(this)
 })
 
-handlebars.registerHelper('displayRepliesButton', function(messageList, message, options) {
-  if (messageList.type === 'channel' && message.isThreadParent)
+handlebars.registerHelper('isChannel', function(messageList, options) {
+  if (messageList.type === 'channel')
+    return options.fn(this)
+  else
+    return options.inverse(this)
+})
+
+handlebars.registerHelper('isThreadParent', function(message, options) {
+  if (message.isThreadParent)
     return options.fn(this)
   else
     return options.inverse(this)

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -25,6 +25,13 @@ handlebars.registerHelper('isChannel', function(messageList, options) {
     return options.inverse(this)
 })
 
+handlebars.registerHelper('isTopLevel', function(message, options) {
+  if (!message.isSub && (!message.threadId || message.isThreadParent))
+    return options.fn(this)
+  else
+    return options.inverse(this)
+})
+
 handlebars.registerHelper('isThreadParent', function(message, options) {
   if (message.isThreadParent)
     return options.fn(this)
@@ -53,7 +60,7 @@ function getMenuCallback(userId, replyEntry, deleteFrom, deleteTo) {
   return menuItem => {
     replyEntry.deleteRange(deleteFrom, deleteTo)
     replyEntry.insertText(`<@${userId}>`)
-  };
+  }
 }
 
 class ChatBox {
@@ -278,12 +285,12 @@ class ChatBox {
 
     // Push existing reactions to top
     const mountedEmojis = {}
-    const emojis = (message.reactions || []).map(reaction => {
+    const emojis = (message && message.reactions || []).map(reaction => {
       mountedEmojis[reaction.name] = true
 
       return {
         type: 'checkbox',
-        label: reaction.name,
+        label: `${reaction.name} (${reaction.count})`,
         checked: reaction.hasCurrentUser,
         onClick: el => this.toggleReaction(reaction.name, channel, messageId)
       }

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -14,11 +14,7 @@
   <hr class="line">
 </div>
 {{/isFirstUnread}}
-{{#if message.isFolded}}
-<div id="{{message.id}}" class="msg folded">
-{{else}}
-<div id="{{message.id}}" class="msg">
-{{/if}}
+<div id="msg{{replace message.id '.' '_'}}" class="msg {{#if message.isFolded}}folded{{/if}}">
   <div class="avatar">
     {{#if message.isFolded}}
     <div class="dummy"></div>

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -14,7 +14,11 @@
   <hr class="line">
 </div>
 {{/isFirstUnread}}
-<div id="msg{{replace message.id '.' '_'}}" class="msg {{#if message.isFolded}}folded{{/if}}">
+<div id="msg{{replace message.id '.' '_'}}"
+     class="msg {{#if message.isFolded}}isFolded{{/if}} {{#isChannel messageList}}isChannel {{#isTopLevel message}}isTopLevel{{/isTopLevel}}{{/isChannel}}"
+     data-channel-id="{{messageList.id}}"
+     data-message-id="{{message.id}}"
+>
   <div class="avatar">
     {{#if message.isFolded}}
     <div class="dummy"></div>
@@ -22,17 +26,7 @@
     <img width="36" height="36" src="{{message.user.avatar}}"/>
     {{/if}}
   </div>
-  <div class="content">
-    {{#isChannel messageList}}
-      {{#isThreadParent message}}
-      {{else}}
-    <nav class="extra-menu">
-      <a href="#" onclick="wey.openReactionMenu('{{messageList.id}}', '{{message.id}}'); return false" title="Add reaction">😶</a>
-      <a href="#" onclick="wey.openThread('{{message.id}}'); return false" title="Start thread">💬</a>
-    </nav>
-      {{/isThreadParent}}
-    {{/isChannel}}
-
+  <div class="content" onmouseenter="MessageHelper.enter(this)">
     {{#unless message.isFolded}}
     <div class="sender">
       <div class="name">{{message.user.name}}</div>

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -25,7 +25,11 @@
   <div class="content">
     {{#isChannel messageList}}
       {{#isThreadParent message}}
-      {{else}}<nav class="extra-menu"><a href="#" onclick="wey.openThread('{{message.id}}'); return false" title="Start thread">💬</a></nav>
+      {{else}}
+    <nav class="extra-menu">
+      <a href="#" onclick="wey.openReactionMenu('{{messageList.id}}', '{{message.id}}'); return false" title="Add reaction">😶</a>
+      <a href="#" onclick="wey.openThread('{{message.id}}'); return false" title="Start thread">💬</a>
+    </nav>
       {{/isThreadParent}}
     {{/isChannel}}
 
@@ -75,9 +79,15 @@
     {{/each}}
     {{#if message.reactions}}
     <div class="reactions">
-    {{#each message.reactions}}
-    <button>{{{content}}}<span class="count">{{count}}</span></button>
-    {{/each}}
+      {{#each message.reactions}}
+      <button title="{{name}}"
+        onclick="wey.toggleReaction('{{name}}', '{{../messageList.id}}', '{{../message.id}}')"
+        {{#if hasCurrentUser}}
+          class="user-emoted"
+        {{/if}}
+      >{{{content}}}<span class="count">{{count}}</span></button>
+      {{/each}}
+      <button title="Add reaction" class="add-emote" onclick="wey.openReactionMenu('{{messageList.id}}', '{{message.id}}')">😶<span class="count">+</span></button>
     </div>
     {{/if}}
     {{#isChannel messageList}}

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -27,6 +27,12 @@
     {{/if}}
   </div>
   <div class="content">
+    {{#isChannel messageList}}
+      {{#isThreadParent message}}
+      {{else}}<nav class="extra-menu"><a href="#" onclick="wey.openThread('{{message.id}}'); return false" title="Start thread">💬</a></nav>
+      {{/isThreadParent}}
+    {{/isChannel}}
+
     {{#unless message.isFolded}}
     <div class="sender">
       <div class="name">{{message.user.name}}</div>
@@ -78,14 +84,16 @@
     {{/each}}
     </div>
     {{/if}}
-    {{#displayRepliesButton messageList message}}
-    <div onclick="wey.openThread('{{message.id}}'); return false" class="replies-wrapper"><div class="replies">
-      {{#each message.replyUsers}}
-      <img width="24" height="24" src="{{avatar}}"/>
-      {{/each}}
-      <a href="#" onclick="return false">{{message.replyCount}} replies</a>
-      <span class="description">View thread</span>
-    </div></div>
-    {{/displayRepliesButton}}
+    {{#isChannel messageList}}
+      {{#isThreadParent message}}
+      <div onclick="wey.openThread('{{message.id}}'); return false" class="replies-wrapper"><div class="replies">
+        {{#each message.replyUsers}}
+        <img width="24" height="24" src="{{avatar}}"/>
+        {{/each}}
+        <a href="#" onclick="return false">{{message.replyCount}} replies</a>
+        <span class="description">View thread</span>
+      </div></div>
+      {{/isThreadParent}}
+    {{/isChannel}}
   </div>
 </div>

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -99,13 +99,44 @@
   }
 
   .msg {
-    margin-top: 10px;
+    border-top: 6px solid transparent;
     display: table;
     width: 100%;
     border-collapse: collapse;
   }
   .msg.folded {
-    margin-top: 0;
+    border-top-width: 0;
+  }
+  .msg:hover {
+    box-shadow: 0 0 10px #E8E8E8;
+  }
+  .extra-menu {
+    display: none;
+    position: absolute;
+    right: 9px;
+    margin-top: -.75em;
+    background: white;
+    border: 1px solid #E8E8E8;
+    border-radius: 6px;
+    font-size: 13px;
+    user-select: none;
+    white-space: nowrap;
+  }
+  .msg:hover .extra-menu {
+    display: block;
+    float: right;
+  }
+  .extra-menu a {
+    display: inline-block;
+    padding: 2px 3px;
+    filter: grayscale(100%);
+    text-decoration: none;
+  }
+  .extra-menu a:hover {
+    filter: grayscale(100%) sepia(100%) saturate(200%);
+  }
+  .extra-menu a:active {
+    filter: grayscale(100%) brightness(90%);
   }
   .msg > div {
     display: table-cell;
@@ -113,6 +144,7 @@
   }
   .msg > .content {
     padding-right: 10px;
+    word-break: break-word;
   }
   .msg > .avatar {
     padding-left: 10px;

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -152,7 +152,7 @@
   }
   .msg > .content {
     padding-right: 10px;
-    word-break: break-word;
+    word-wrap: break-word;
   }
   .msg > .avatar {
     padding-left: 10px;
@@ -214,9 +214,10 @@
     font-weight: normal;
   }
   .text pre, .text code {
-    word-break: break-all;
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
     tab-size: 2;
+    word-break: break-word;
+    word-wrap: break-word;
   }
   .text pre {
     padding: .5rem;

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -275,16 +275,37 @@
     margin-bottom: 4px;
   }
   .reactions button {
+    color: #717274;
+    cursor: pointer;
     font-size: 11px;
     line-height: 16px;
-    padding: 2px 3px;
     margin: 0;
+    padding: 2px 3px;
     background: #FFF;
     border: 1px solid #E8E8E8;
     border-radius: 5px;
   }
+  .reactions button:hover {
+    color: #0576b9;
+    background: #eee;
+  }
+  .reactions button.user-emoted {
+    color: #0576b9;
+    background-color: #e6f6ff;
+    border-color: #0576b9;
+  }
+  .reactions button.user-emoted:hover {
+    color: #0576b9;
+    background: #b1bcc3;
+  }
+  .reactions button.user-emoted:focus {
+    color: #fff;
+    background: #0576b9;
+  }
+  .reactions button.add-emote {
+    filter: grayscale(100%);
+  }
   .reactions .count {
-    color: #717274;
     padding: 0 1px 0 3px;
   }
 
@@ -362,7 +383,7 @@
   }
   // External API to delete message.
   window.deleteMessage = function(id) {
-    messages.removeChild(document.getElementById(id))
+    messages.removeChild(document.getElementById(`msg${id.replace('.', '_')}`))
   }
   // Which element is on top.
   var topElement = null
@@ -378,7 +399,7 @@
   }
   // External API to modify message.
   window.modifyMessage = function(id, html) {
-    var msg = document.getElementById(id)
+    var msg = document.getElementById(`msg${id.replace('.', '_')}`)
     if (msg) {
       // Ignore dayMarker and unreadMarker, only find the message part.
       var newMsg

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -137,7 +137,15 @@
   }
   .extra-menu a:active {
     filter: grayscale(100%) brightness(90%);
+    background: #eee;
   }
+  .extra-menu a.extra-menu-thread {
+    display: none;
+  }
+  .isTopLevel .extra-menu a.extra-menu-thread {
+    display: inline-block;
+  }
+
   .msg > div {
     display: table-cell;
     vertical-align: top;
@@ -349,6 +357,46 @@
   {{> messagePartial messageList=../messageList message=this}}
 {{/each}}
 </div>
+
+<nav id="extra-menu" class="extra-menu">
+  <a class="extra-menu-reaction" href="#" onclick="return MessageHelper.openReactionMenu(this)" title="Add reaction">😶</a>
+  <a class="extra-menu-thread" href="#" onclick="return MessageHelper.openThread(this)" title="Start thread">💬</a>
+</nav>
+<script>
+  // Optimize extra-menu by not replicating it on every message; just move it onMouseEnter
+  const extraMenu = document.getElementById('extra-menu');
+
+  function getMessageData(element) {
+    for (let parent = element; parent = parent.parentNode;) {
+      if (parent === window)
+        return false;
+      if (parent.dataset && parent.dataset.channelId)
+        return parent.dataset;
+    }
+    return false;
+  }
+
+  const MessageHelper = {
+    enter: target => {
+      target.insertBefore(extraMenu, target.firstChild);
+    },
+
+    openReactionMenu: button => {
+      const data = getMessageData(button);
+      if (data)
+        wey.openReactionMenu(data.channelId, data.messageId);
+      return false;
+    },
+
+    openThread: button => {
+      const data = getMessageData(button);
+      if (data)
+        wey.openThread(data.messageId);
+      return false;
+    }
+  };
+</script>
+
 <script type="text/javascript" charset="utf-8">
   // Scroll to the unread marker, or bottom if not found.
   var marker = document.getElementById('unread-marker')


### PR DESCRIPTION
9 individual commits:

- Add @mentions in chat-box
- Avoid unhandled exception of sending empty message 
- Fix "unknown" typos
- Fix new threads not activating
- Add hover menu to messages
- Fix invalid HTML IDs
- Add message reactions
- Optimize message hover menu by using 1 instance
- Break words only when lines are too long

Known issues:
- "Add reaction" list only shows Slack custom emotes; Slack does not have a
      way of getting standard emojis, though 1 MB JSON npm module exists for it.
- Currently accessing `rtm` directly in `chat-box.js`; it does not belong there.
      This is temporary until we move that logic back into `SlackAccount`.
- `View.onKeyDown` is only triggering for modifier keys (MacOS only?). This
      requires a hack that we have to delete the inserted tab instead of preventing
      preventing it entirely.
- `Menu.popup()` does not allow you to specify a location, so the users list
      appears at the mouse cursor, instead of the text caret.
- There is no way to show the "pretty" user name at the moment. In a future
      version, we could potentially show the username as usual, while keeping
      track of the its string position, then render a highlight on top -- and
      finally re-process the message on send to inject the stored `<@id>`.

Original single-commit PR of @mentions: https://github.com/yue/wey/pull/64