### PR TITLE
Add reaction modification, correct thread updating

### DIFF
--- a/lib/model/account.js
+++ b/lib/model/account.js
@@ -56,9 +56,19 @@ class Account {
     return this.dms.find((c) => c.userId === id)
   }
 
+  findUserById(id) {
+    return this.users[id]
+  }
+
   computeReadState() {
     const compute = (r, c) => { return (c.isRead || c.isMuted) ? r : false }
     return this.channels.reduce(compute, this.dms.reduce(compute, true))
+  }
+
+  // Save user for ID lookup
+  saveUser(newUser) {
+    this.users[newUser.id] = newUser
+    return newUser
   }
 
   setReadState(read) {

--- a/lib/model/channel.js
+++ b/lib/model/channel.js
@@ -42,15 +42,6 @@ class Channel extends MessageList {
       this.account.setReadState(false)
   }
 
-  updateMessageStar(id, timestamp, hasStar) {
-    const message = super.updateMessageStar(id, timestamp, hasStar)
-    if (message && message.threadId) {
-      const thread = this.findThread(message.threadId)
-      if (thread)
-        thread.updateMessageStar(id, timestamp, hasStar)
-    }
-  }
-
   async dispatchMessage(message) {
     await super.dispatchMessage(message)
     if (!this.isDisplaying)

--- a/lib/model/message-list.js
+++ b/lib/model/message-list.js
@@ -129,11 +129,6 @@ class MessageList {
     return -1
   }
 
-  findMessage(id, timestamp) {
-    const i = this.findMessageIndex(id, timestamp)
-    return i === -1 ? null : this.messages[i]
-  }
-
   async dispatchMessage(message) {
     // Update latest ts.
     if (this.latestTs * 1 < message.timestamp * 1)
@@ -230,10 +225,9 @@ class MessageList {
   modifyMessage(id, timestamp, modified) {
     if (!this.isReceiving)
       return
-    const i = this.findMessageIndex(id, timestamp)
-    if (i === -1)
+    const original = this.findMessage(id, timestamp)
+    if (!original)
       return
-    const original = this.messages[i]
     // Save old properties.
     const old = Object.assign({}, original)
     // Copy properties, we should NOT assign directly since it would change the
@@ -264,10 +258,11 @@ class MessageList {
 
     const { channels, message } = this.findMessageAndChannels(messageId, timestamp)
     if (message) {
-      const existing = message.reactions && message.reactions.find((r) => r.name === reaction.name)
-      if (existing)
+      const existing = message.reactions.find((r) => r.name === reaction.name)
+      if (existing) {
         ++existing.count
-      else
+        existing.hasCurrentUser = reaction.hasCurrentUser
+      } else
         message.reactions.push(reaction)
 
       this.dispatchToAll('onModifyMessage', channels, messageId, message)
@@ -284,6 +279,8 @@ class MessageList {
         return
       if (--message.reactions[i].count === 0) {
         message.reactions.splice(i, 1)
+      } else {
+        message.reactions[i].hasCurrentUser = reaction.hasCurrentUser
       }
       this.dispatchToAll('onModifyMessage', channels, messageId, message)
     }
@@ -298,7 +295,7 @@ class MessageList {
     const messages = await this.readMessagesPromise
     this.readMessagesPromise = null
     // Concatenate messages.
-    this.messages = this.foldMessages(messages).concat(this.messages)
+    this.saveAndFoldMessages(messages)
     // Update latestTs.
     if (!this.latestTs && this.hasMessages())
       this.latestTs = this.latestMessage().timestamp
@@ -337,9 +334,9 @@ class MessageList {
   }
 
   // Compute day markers and whether messages should be folded.
-  foldMessages(messages) {
-    for (const i in messages) {
-      if (i == 0) {
+  saveAndFoldMessages(messages) {
+    for (let i = messages.length; i--;) {
+      if (i === 0)
         messages[i].setDayMarker()
       else
         this.compareMessage(messages[i], messages[i - 1])
@@ -347,7 +344,6 @@ class MessageList {
       this.messageIds.unshift(messages[i].id)
       this.messages[messages[i].id] = messages[i]
     }
-    return messages
   }
 
   compareMessage(m, pm) {

--- a/lib/model/message-list.js
+++ b/lib/model/message-list.js
@@ -10,7 +10,8 @@ class MessageList {
     this.account = account
     this.type = type
     this.id = id
-    this.messages = []
+    this.messages = {}
+    this.messageIds = []
     this.mentions = 0
 
     // Whether all messages of channel have been read.
@@ -106,27 +107,24 @@ class MessageList {
 
   clear() {
     this.messagesReady = false
-    this.messages = []
+    this.messages = {}
+    this.messageIds = []
   }
 
   hasMessages() {
-    return this.messages.length > 0
+    return !!this.messageIds[0]
   }
 
   latestMessage() {
-    return this.messages[this.messages.length - 1]
+    return this.messages[this.messageIds[this.messageIds.length - 1]]
   }
 
-  findMessageIndex(id, timestamp) {
-    if (!this.hasMessages())
-      return -1
-    const date = new Date(timestamp * 1000)
-    for (let i = this.messages.length - 1; i >= 0; --i) {
-      const message = this.messages[i]
-      if (message.id === id)
-        return i
-      if (message.date < date)
-        return -1
+  findMessage(id, timestamp) {
+    if (this.hasMessages()) {
+      const date = new Date(timestamp * 1000)
+      const message = this.messages[id]
+      if (message && message.id === id && message.date >= date)
+        return message
     }
     return -1
   }
@@ -170,12 +168,16 @@ class MessageList {
     // Handle thew new message.
     if (this.hasMessages())
       this.compareMessage(message, this.latestMessage())
-    this.messages.push(message)
+    this.messageIds.push(message.id)
     // Limit the size of cached messages, remove many items to avoid calling
     // splice too often.
-    if (this.messages.length > CACHE_MESSAGES_LIMIT) {
-      this.messages.splice(0, 50)
-      this.messages[0].setDayMarker()
+    if (this.messageIds.length > CACHE_MESSAGES_LIMIT) {
+      this.messageIds.splice(0, 50)
+      this.messages = this.messageIds.reduce((map, messageId) => {
+        map[messageId] = this.messages[messageId]
+        return map
+      }, {})
+      this.messages[this.messageIds[0]].setDayMarker()
     }
     // Dispatch the message.
     this.onMessage.dispatch(message)
@@ -184,10 +186,14 @@ class MessageList {
   deleteMessage(id, timestamp) {
     if (!this.isReceiving)
       return
-    const i = this.findMessageIndex(id, timestamp)
-    if (i !== -1) {
-      this.messages.splice(i, 1)
-      this.onDeleteMessage.dispatch(id, timestamp)
+    const message = this.findMessage(id, timestamp)
+    if (message) {
+      const index = this.messageIds.indexOf(message.id)
+      if (index > -1) {
+        this.messageIds.splice(index, 1)
+        delete this.messages[id]
+        this.onDeleteMessage.dispatch(id, timestamp)
+      }
     }
   }
 
@@ -253,7 +259,7 @@ class MessageList {
 
   async readMessages() {
     if (this.messagesReady)
-      return this.messages
+      return this.messageIds.map(id => this.messages[id])
     // Handle parallel reads.
     if (!this.readMessagesPromise)
       this.readMessagesPromise = this.readMessagesImpl()
@@ -270,9 +276,11 @@ class MessageList {
     // messages.
     if (this.account.status === 'connected')
       this.messagesReady = true
-    else
-      this.messages = []
-    return this.messages
+    else {
+      this.messages = {}
+      this.messageIds = []
+    }
+    return this.messageIds.map(id => this.messages[id])
   }
 
   async readMessagesImpl() {
@@ -285,7 +293,7 @@ class MessageList {
 
   async notifyRead() {
     this.markRead()
-    if (this.messages.length == 0)
+    if (this.messageIds.length === 0)
       return
     if (this.markTimer)
       clearTimeout(this.markTimer)
@@ -301,9 +309,11 @@ class MessageList {
     for (const i in messages) {
       if (i == 0) {
         messages[i].setDayMarker()
-        continue
-      }
-      this.compareMessage(messages[i], messages[i - 1])
+      else
+        this.compareMessage(messages[i], messages[i - 1])
+
+      this.messageIds.unshift(messages[i].id)
+      this.messages[messages[i].id] = messages[i]
     }
     return messages
   }

--- a/lib/model/message-list.js
+++ b/lib/model/message-list.js
@@ -183,16 +183,46 @@ class MessageList {
     this.onMessage.dispatch(message)
   }
 
-  deleteMessage(id, timestamp) {
+  findMessageAndChannels(messageId, timestamp) {
+    let channels = [this];
+    let message = this.findMessage(messageId, timestamp)
+
+    if (message && message.isThreadParent && this.openedThreads) {
+      // Opened threads also need to be dispatched
+      for (const thread of this.openedThreads) {
+        if (message = thread.findMessage(messageId, timestamp)) {
+          channels.push(thread)
+          break
+        }
+      }
+    } else if (!message) {
+      // Check if this reaction was added to a message in an opened thread
+      for (const thread of this.openedThreads) {
+        if (message = thread.findMessage(messageId, timestamp)) {
+          channels = [thread]
+          break
+        }
+      }
+    }
+
+    return { channels, message }
+  }
+
+  dispatchToAll(event, channels, messageId, data) {
+    for (const channel of channels)
+      channel[event].dispatch(messageId, data)
+  }
+
+  deleteMessage(messageId, timestamp) {
     if (!this.isReceiving)
       return
-    const message = this.findMessage(id, timestamp)
+    const { channels, message } = this.findMessageAndChannels(messageId, timestamp)
     if (message) {
       const index = this.messageIds.indexOf(message.id)
       if (index > -1) {
         this.messageIds.splice(index, 1)
-        delete this.messages[id]
-        this.onDeleteMessage.dispatch(id, timestamp)
+        delete this.messages[messageId]
+        this.dispatchToAll('onDeleteMessage', channels, messageId, timestamp)
       }
     }
   }
@@ -215,45 +245,47 @@ class MessageList {
     this.onModifyMessage.dispatch(id, original)
   }
 
-  async setMessageStar(id, timestamp, hasStar) {
+  async setMessageStar(messageId, timestamp, hasStar) {
     throw new Error('Should be implemented by subclasses')
   }
 
-  updateMessageStar(id, timestamp, hasStar) {
-    const message = this.findMessage(id, timestamp)
+  updateMessageStar(messageId, timestamp, hasStar) {
+    const { channels, message } = this.findMessageAndChannels(messageId, timestamp)
     if (message && message.hasStar !== hasStar) {
       message.hasStar = hasStar
-      this.onModifyMessage.dispatch(id, message)
+      this.dispatchToAll('onModifyMessage', channels, messageId, message)
     }
     return message
   }
 
-  addReaction(id, timestamp, reaction) {
+  addReaction(messageId, timestamp, reaction) {
     if (!this.isReceiving)
       return
-    const message = this.findMessage(id, timestamp)
-    if (!message)
-      return
-    const existing = message.reactions.find((r) => r.name === reaction.name)
-    if (existing)
-      ++existing.count;
-    else
-      message.reactions.push(reaction)
-    this.onModifyMessage.dispatch(id, message)
+
+    const { channels, message } = this.findMessageAndChannels(messageId, timestamp)
+    if (message) {
+      const existing = message.reactions && message.reactions.find((r) => r.name === reaction.name)
+      if (existing)
+        ++existing.count
+      else
+        message.reactions.push(reaction)
+
+      this.dispatchToAll('onModifyMessage', channels, messageId, message)
+    }
   }
 
-  removeReaction(id, timestamp, reaction) {
+  removeReaction(messageId, timestamp, reaction) {
     if (!this.isReceiving)
       return
-    const message = this.findMessage(id, timestamp)
-    if (!message)
-      return
-    const i = message.reactions.findIndex((r) => r.name === reaction.name)
-    if (i === -1)
-      return
-    if (--message.reactions[i].count === 0) {
-      message.reactions.splice(i, 1)
-      this.onModifyMessage.dispatch(id, message)
+    const { channels, message } = this.findMessageAndChannels(messageId, timestamp)
+    if (message) {
+      const i = message.reactions.findIndex((r) => r.name === reaction.name)
+      if (i === -1)
+        return
+      if (--message.reactions[i].count === 0) {
+        message.reactions.splice(i, 1)
+      }
+      this.dispatchToAll('onModifyMessage', channels, messageId, message)
     }
   }
 

--- a/lib/model/reaction.js
+++ b/lib/model/reaction.js
@@ -1,8 +1,9 @@
 class Reaction {
-  constructor(name, count, content) {
+  constructor(name, count, content, hasCurrentUser) {
     this.name = name
     this.count = count
     this.content = content
+    this.hasCurrentUser = hasCurrentUser
   }
 }
 

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -113,8 +113,11 @@ class SlackAccount extends Account {
     // Fetch users.
     // TODO We need a better policy for users cache.
     const {members} = await this.rtm.webClient.users.list()
-    for (const m of members)
-      this.users[m.id] = new SlackUser(this, m)
+    for (const m of members) {
+      // Don't handle deleted users unless we specifically need them in fetchUser
+      if (m.deleted !== true)
+        this.saveUser(m)
+    }
     // Current user.
     this.currentUserId = data.self.id
     this.currentUserName = data.self.name
@@ -357,8 +360,9 @@ class SlackAccount extends Account {
     this.updatePresenceSubscription()
   }
 
-  findUserById(id) {
-    return this.users[id]
+  // Save user for ID lookup
+  saveUser(member) {
+    return super.saveUser(new SlackUser(this, member))
   }
 
   async fetchUser(id, isBot) {
@@ -376,7 +380,7 @@ class SlackAccount extends Account {
       const {user} = await this.rtm.webClient.users.info({user: id})
       member = user
     }
-    return this.users[id] = new SlackUser(this, member)
+    return this.saveUser(member)
   }
 
   async listChannels(options, filter) {

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -15,7 +15,7 @@ function compareChannel(a, b) {
   const nameB = b.name.toUpperCase()
 
   // Push muted channels to bottom of list.
-  if (a.is_muted === b.is_muted) {
+  if (a.isMuted === b.isMuted) {
     if (nameA < nameB)
       return -1
     if (nameA > nameB)
@@ -23,7 +23,7 @@ function compareChannel(a, b) {
     return 0
   }
 
-  if (a.is_muted)
+  if (a.isMuted)
     return 1
 
   return -1
@@ -145,8 +145,8 @@ class SlackAccount extends Account {
     const {channels, groups, ims, mpims} = await this.rtm.webClient.users.counts(options)
     this.channels = channels.concat(groups)
                             .filter(filterChannel)
-                            .sort(compareChannel)
                             .map((c) => new SlackChannel(this, c))
+                            .sort(compareChannel)
     this.dms = ims.concat(mpims)
                   .filter(filterDM)
                   .map((c) => new SlackDirectMessage(this, c))

--- a/lib/service/slack/slack-account.js
+++ b/lib/service/slack/slack-account.js
@@ -280,7 +280,19 @@ class SlackAccount extends Account {
     const channel = this.findChannelById(event.item.channel)
     if (!channel)
       return
-    const reaction = new SlackReaction(this, event.reaction, 1)
+
+    const users = []
+    if (event.user === this.currentUserId) {
+      // User just added a react
+      users.push(this.currentUserId)
+    } else {
+      // Did user previously react to this?
+      const message = channel.findMessage(event.item.ts, event.item.ts)
+      if (message && message.reactions && message.reactions.hasCurrentUser)
+        users.push(this.currentUserId)
+    }
+
+    const reaction = new SlackReaction(this, event.reaction, 1, users)
     channel.addReaction(event.item.ts, event.item.ts, reaction)
   }
 
@@ -288,7 +300,16 @@ class SlackAccount extends Account {
     const channel = this.findChannelById(event.item.channel)
     if (!channel)
       return
-    const reaction = new SlackReaction(this, event.reaction, -1)
+
+    const users = []
+    if (event.user !== this.currentUserId) {
+      // Did user previously react to this?
+      const message = channel.findMessage(event.item.ts, event.item.ts)
+      if (message && message.reactions && message.reactions.hasCurrentUser)
+        users.push(this.currentUserId)
+    }
+
+    const reaction = new SlackReaction(this, event.reaction, -1, users)
     channel.removeReaction(event.item.ts, event.item.ts, reaction)
   }
 

--- a/lib/service/slack/slack-channel.js
+++ b/lib/service/slack/slack-channel.js
@@ -21,6 +21,7 @@ class SlackChannel extends Channel {
       this.description = event.purpose.value
     if (event.is_muted)
       this.isMuted = true
+    this.latestId = null
   }
 
   openThreadImpl(id) {
@@ -45,12 +46,24 @@ class SlackChannel extends Channel {
     // Read messages.
     const options = {channel: this.id}
     if (this.hasMessages())
-      options.latest = this.messages[0]
-    const {messages} = await this.account.rtm.webClient.conversations.history(options)
-    // Converting messages.
-    const smsgs = messages.reverse().map((m) => new SlackMessage(this.account, m))
-    for (const m of smsgs)  // slack messages have async info.
-      await m.fetchPendingInfo(this.account)
+      options.latest = this.latestId
+
+      const {messages} = await this.account.rtm.webClient.conversations.history(options)
+
+    if (messages[0])
+      this.latestId = messages[0].id
+
+      // Converting messages.
+    const pendingMessages = []
+    const smsgs = messages.reduceRight((smsgs, msg) => {
+      const slackMessage = new SlackMessage(this.account, msg)
+      smsgs.push(slackMessage)
+      pendingMessages.push(slackMessage.fetchPendingInfo(this.account))
+      return smsgs
+    }, [])
+
+    await Promise.all(pendingMessages) // slack messages have async info.
+
     return smsgs
   }
 

--- a/lib/service/slack/slack-channel.js
+++ b/lib/service/slack/slack-channel.js
@@ -29,7 +29,7 @@ class SlackChannel extends Channel {
   }
 
   async setMessageStar(id, timestamp, hasStar) {
-    const message = this.findMessage(id, timestamp)
+    const { channels, message } = this.findMessageAndChannels(id, timestamp)
     if (message) {
       // Slack does not send event after adding star.
       this.updateMessageStar(id, timestamp, hasStar)

--- a/lib/service/slack/slack-message.js
+++ b/lib/service/slack/slack-message.js
@@ -24,7 +24,7 @@ class SlackMessage extends Message {
     if (event.is_starred)
       this.hasStar = true
     if (event.reactions)
-      this.reactions = event.reactions.map((r) => new SlackReaction(account, r.name, r.count))
+      this.reactions = event.reactions.map(r => new SlackReaction(account, r.name, r.count, r.users))
     if (event.thread_ts) {
       this.threadId = event.thread_ts
       if (event.thread_ts === event.ts) {

--- a/lib/service/slack/slack-reaction.js
+++ b/lib/service/slack/slack-reaction.js
@@ -11,9 +11,10 @@ function normalizeReactionName(name) {
 }
 
 class SlackReaction extends Reaction {
-  constructor(account, name, count) {
+  constructor(account, name, count, users) {
     name = normalizeReactionName(name)
-    super(name, count, parseEmoji(account, 16, name))
+    const hasCurrentUser = users && users.indexOf(account.currentUserId) > -1
+    super(name, count, parseEmoji(account, 16, name), hasCurrentUser)
   }
 }
 

--- a/lib/service/slack/slack-thread.js
+++ b/lib/service/slack/slack-thread.js
@@ -11,7 +11,7 @@ class SlackThread extends Thread {
     const message = this.findMessage(id, timestamp)
     if (message) {
       // Slack does not send event after adding star.
-      this.updateMessageStar(id, timestamp, hasStar)
+      this.channel.updateMessageStar(id, timestamp, hasStar)
       // Send message after we update the message.
       const options = {channel: this.channel.id, timestamp: id}
       if (hasStar)

--- a/lib/theme/dark/index.js
+++ b/lib/theme/dark/index.js
@@ -3,8 +3,10 @@ const gui = require('gui')
 const darkTheme = {
   channelHeader: {
     height: 45,
-    padding: 10,
-    font: gui.Font.default().derive(4, 'bold', 'normal'),
+    paddingX: 10,
+    paddingY: 5,
+    nameFont: gui.Font.default().derive(3, 'bold', 'normal'),
+    descriptionFont: gui.Font.default().derive(-1, 'normal', 'normal'),
     fontColor: '#2C2D30',
     borderColor: '#E5E5E5',
     backgroundColor: '#FFF',

--- a/lib/view/channel-header.js
+++ b/lib/view/channel-header.js
@@ -23,29 +23,36 @@ class ChannelHeader {
       this.channelTitle = (channel.isPrivate ? 'θ' : '#') + ' ' + channel.name
     else
       this.channelTitle = channel.name
-    this.view.setVisible(true)
+    this.view.setVisible(!!this.channelTitle)
     this.view.schedulePaint()
   }
 
   draw(view, painter, dirty) {
     const bounds = view.getBounds()
-    if (this.channel)
+    if (this.channel && this.channelTitle)
       this.drawChannelTitle(painter, bounds)
+    else
+      this.view.setVisible(false)
     this.drawBottomBorder(painter, bounds)
   }
 
   drawChannelTitle(painter, bounds) {
     const attributes = {
       color: theme.channelHeader.fontColor,
-      font: theme.channelHeader.font,
+      font: theme.channelHeader.nameFont,
     }
     const textRect = {
-      x: theme.channelHeader.padding,
-      y: theme.channelHeader.padding,
+      x: theme.channelHeader.paddingX,
+      y: theme.channelHeader.paddingY,
       width: bounds.width,
       height: bounds.height,
     }
     painter.drawText(this.channelTitle, textRect, attributes)
+
+    const description = this.channel.type === 'channel' ? this.channel.description : 'Private chat'
+    textRect.y += attributes.font.getSize() + theme.channelHeader.paddingY
+    attributes.font = theme.channelHeader.descriptionFont
+    painter.drawText(description, textRect, attributes)
   }
 
   drawBottomBorder(painter, bounds) {

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -81,6 +81,7 @@ class ChatBox {
     this.browser.addBinding('setMessageStar', this.setMessageStar.bind(this))
     this.browser.addBinding('notifyDisplaying', this.notifyDisplaying.bind(this))
     this.browser.addBinding('notifyNotDisplaying', this.notifyNotDisplaying.bind(this))
+    this.browser.addBinding('toggleReaction', this.toggleReaction.bind(this))
     this.view.addChildView(this.browser)
 
     this.replyBox = gui.Container.create()
@@ -226,6 +227,30 @@ class ChatBox {
     linkStore.setText(link)
     linkStore.selectAll()
     linkStore.cut()
+  }
+
+  async toggleReaction(name, channelId, timestamp) {
+    const channel = this.messageList.channel ? this.messageList.channel.id : channelId
+    const message = this.messageList.findMessage(timestamp, timestamp)
+
+    if (message && message.reactions) {
+      if (message.reactions.find(reaction => reaction.name === name && reaction.hasCurrentUser)) {
+        // @todo This is a hack. Don't fetch directly from RTM SDK here!
+        await this.messageList.account.rtm.webClient.reactions.remove({
+          name,
+          channel,
+          timestamp
+        })
+        return
+      }
+    }
+
+    // @todo This is a hack. Don't fetch directly from RTM SDK here!
+    await this.messageList.account.rtm.webClient.reactions.add({
+      name,
+      channel,
+      timestamp
+    })
   }
 
   openLinkContextMenu(link) {

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -68,7 +68,7 @@ class ChatBox {
     this.channelHeader = new ChannelHeader()
     // TODO Re-enable header when loading indicator is reimplemented with native
     // UI, otherwise our UI would feel unsmooth.
-    // this.view.addChildView(this.channelHeader.view)
+    this.view.addChildView(this.channelHeader.view)
 
     this.browser = gui.Browser.create({devtools: true, contextMenu: true})
     this.browser.setStyle({flex: 1})

--- a/lib/view/chat-box.js
+++ b/lib/view/chat-box.js
@@ -33,7 +33,7 @@ handlebars.registerHelper('canStartThread', function(messageList, message, optio
 })
 
 handlebars.registerHelper('normalizeId', function(id) {
-  return 'msg' + id.replace('.', '_')
+  return 'msg' + String(id).replace('.', '_')
 })
 
 const fontStyle = fs.readFileSync(path.join(__dirname, 'chat', 'font.css')).toString()

--- a/lib/view/chat/message.html
+++ b/lib/view/chat/message.html
@@ -74,9 +74,14 @@
     {{/each}}
     {{#if message.reactions}}
     <div class="reactions">
-    {{#each message.reactions}}
-    <button>{{{content}}}<span class="count">{{count}}</span></button>
-    {{/each}}
+      {{#each message.reactions}}
+      <button title="{{name}}"
+        onclick="wey.toggleReaction('{{name}}', '{{../messageList.id}}', '{{../message.id}}')"
+        {{#if hasCurrentUser}}
+          class="user-emoted"
+        {{/if}}
+      >{{{content}}}<span class="count">{{count}}</span></button>
+      {{/each}}
     </div>
     {{/if}}
     {{#isChannel messageList}}{{#if message.isThreadParent}}

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -287,16 +287,37 @@
     margin-bottom: 4px;
   }
   .reactions button {
+    color: #717274;
+    cursor: pointer;
     font-size: 11px;
     line-height: 16px;
-    padding: 2px 3px;
     margin: 0;
+    padding: 2px 3px;
     background: #FFF;
     border: 1px solid #E8E8E8;
     border-radius: 5px;
   }
+  .reactions button:hover {
+    color: #0576b9;
+    background: #eee;
+  }
+  .reactions button.user-emoted {
+    color: #0576b9;
+    background-color: #e6f6ff;
+    border-color: #0576b9;
+  }
+  .reactions button.user-emoted:hover {
+    color: #0576b9;
+    background: #b1bcc3;
+  }
+  .reactions button.user-emoted:focus {
+    color: #fff;
+    background: #0576b9;
+  }
+  .reactions button.add-emote {
+    filter: grayscale(100%);
+  }
   .reactions .count {
-    color: #717274;
     padding: 0 1px 0 3px;
   }
 

--- a/lib/view/chat/page.html
+++ b/lib/view/chat/page.html
@@ -418,7 +418,7 @@
   function findParent(tagName, target) {
     var loops = 0
     while (target && ++loops < 4) {
-      if (target.tagName.toLowerCase() === tagName)
+      if (target.tagName && target.tagName.toLowerCase() === tagName)
         return target
       target = target.parentNode
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist": "yackage dist out --cache-dir yode --unpack \"+(*.node|*.html|*.png)\""
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.11.2",
     "yode": "0.3.4"
   },
   "license": "GPL-3.0",


### PR DESCRIPTION
* Add ability to toggle message emoji reactions
Does not include the reaction menu. This only adds the ability to +1 or -1 an existing reaction.
* Dispatch `MessageList` events to thread children
This fixes how thread messages do not correctly receive updates, nor do they update the thread's parent message in the channel. There's definitely a better way of doing this, but this is a good stop-gap measure.
* Store messages by ID in `messageList`
This is a less drastic version of my last patch to change the data structure. It's not necessary, but the commits for dispatching MessageList events will be way more optimized if we can reference messages directly by ID. This is similar to how 
* Optimize `readMessagesImpl` to work in 1 pass
* Fix replace when id is a Number
* Clean up user storage logic to account
* Add back chat room header
Could live without this, but it's nice to have the channel header in. Still not sure why channel purpose don't show up correctly; they're all listed as "(No description)".
* Fix error when going up DOM tree at `parent.tagName`
* Fix sorting channels by `isMuted`
* Set minimum version to node `8.11.2`
Potential fix as described by websockets/ws#1354 and slackapi/node-slack-sdk#531